### PR TITLE
[Hotfix] Remove linebreakstyle for linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,10 +28,7 @@
             "error",
             2
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
+        "linebreak-style": 0,
         "quotes": [
             "error",
             "single"


### PR DESCRIPTION
### Issue
For windows, the EOL line break style checker in linter is giving out errors since it is not UNIX.

### Definition of Done
- [ ] No more error regarding EOL line break style during `yarn run lint`

### Commands to Run
```
yarn install
yarn run lint
```

