### PR TITLE
E_CLASSROOM-171 [Bugfix] [FE] [Student] Fix Ordering of Categories if…

### DIFF
--- a/src/pages/student/categories/CategoryDetail/index.module.css
+++ b/src/pages/student/categories/CategoryDetail/index.module.css
@@ -22,7 +22,7 @@
   display: grid;
   grid-column-gap: 48px;
   grid-row-gap: 48px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: 342px 342px 342px 342px;
   grid-template-rows: 216px 216px 216px;
   height: 747px;
   width: 1518px;

--- a/src/pages/student/categories/CategoryList/index.module.css
+++ b/src/pages/student/categories/CategoryList/index.module.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-column-gap: 48px;
   grid-row-gap: 48px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: 342px 342px 342px 342px;
   grid-template-rows: 216px 216px 216px;
   height: 747px;
   width: 1518px;

--- a/src/pages/student/main/Dashboard/components/Recent/index.js
+++ b/src/pages/student/main/Dashboard/components/Recent/index.js
@@ -8,7 +8,6 @@ import style from './index.module.css';
 
 
 const Recent = props => {
-  console.log(props);
   return (
     <Card className={style.bg}>
       <Card.Header className={style.forContainerBar}>

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
@@ -60,7 +60,7 @@ const QuestionGrid = ({ quiz }) => {
         {quiz.answerCount === 0 ? (
           ''
         ) : (
-          <Card.Text className={style.ResultscoreCardText}>
+          <div className={style.ResultscoreCardText}>
             <div className={style.ResultScore}>
               <p>Attempts</p>
               <p>N/A</p>
@@ -74,7 +74,7 @@ const QuestionGrid = ({ quiz }) => {
               <p>N/A</p>
             </div>
             {/* {`${quiz.correctAnswers}/${quiz.totalQuestions}`} */}
-          </Card.Text>
+          </div>
         )}
       </Card.Body>
       {quiz.answerCount === 0 || (

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.css
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.css
@@ -62,7 +62,6 @@
   color: #5D9098;
   margin-bottom: 9px;
   font-weight: bold;
-  width: 385px;
   margin-top: 0px;
   font-size: 16px;
 }
@@ -95,5 +94,5 @@
 
 
 .carddiv{
-  width: 385px;
+  width: 339px;
 }

--- a/src/pages/student/quizzes/QuizList/index.js
+++ b/src/pages/student/quizzes/QuizList/index.js
@@ -26,7 +26,6 @@ const QuizList = () => {
   useEffect(() => {
     QuizApi.getAll(categoryId, page)
       .then(({ data }) => {
-        console.log(data);
         setQuizzes(data.data);
         setPerPage(data.per_page);
         setTotalItems(data.total);

--- a/src/pages/student/quizzes/QuizList/index.js
+++ b/src/pages/student/quizzes/QuizList/index.js
@@ -61,7 +61,7 @@ const QuizList = () => {
         ''
       )}
       <div>
-        {quizzes && (
+        {quizzes && (quizzes.length > 0) && (
           <div id={style.GridCard}>
             {/* <Row xs={1} sm={2} md={3} lg={3}> */}
             {quizzes.map((quiz, index) => {

--- a/src/pages/student/quizzes/QuizList/index.js
+++ b/src/pages/student/quizzes/QuizList/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-import { Row, Col, Spinner } from 'react-bootstrap';
+import { Col, Spinner } from 'react-bootstrap';
 import Pagination from '../../../../components/Pagination';
 import { BsFillArrowLeftSquareFill } from 'react-icons/bs';
 
@@ -61,14 +61,13 @@ const QuizList = () => {
       ) : (
         ''
       )}
-      <Row xs={1} sm={2} md={3} lg={3}>
-        {quizzes &&
-          quizzes.map((quiz, index) => {
-            if (index + 1 > perPage) {
-              return;
-            } else {
+      <div>
+        {quizzes && (
+          <div id={style.GridCard}>
+            {/* <Row xs={1} sm={2} md={3} lg={3}> */}
+            {quizzes.map((quiz, index) => {
               return (
-                <Col id={style.GridCard} key={index}>
+                <Col key={index}>
                   <a
                     href={`/categories/${categoryId}/quizzes/${quiz.id}/questions`}
                   >
@@ -76,9 +75,11 @@ const QuizList = () => {
                   </a>
                 </Col>
               );
-            }
-          })}
-      </Row>
+            })}
+            {/* </Row> */}
+          </div>
+        )}
+      </div>
 
       {quizzes?.length <= 0 ? (
         <div className={style.noResultsMessage}>

--- a/src/pages/student/quizzes/QuizList/index.js
+++ b/src/pages/student/quizzes/QuizList/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
-import { Container, Row, Col, Spinner } from 'react-bootstrap';
+import { Row, Col, Spinner } from 'react-bootstrap';
 import Pagination from '../../../../components/Pagination';
 import { BsFillArrowLeftSquareFill } from 'react-icons/bs';
 

--- a/src/pages/student/quizzes/QuizList/index.js
+++ b/src/pages/student/quizzes/QuizList/index.js
@@ -48,7 +48,7 @@ const QuizList = () => {
   };
 
   return (
-    <Container className={style.container}>
+    <div className={style.container}>
       <a href='/categories'>
         <BsFillArrowLeftSquareFill className={style.backarrow} />
         <p className={style.title}>{category?.name}</p>
@@ -95,7 +95,7 @@ const QuizList = () => {
           ></Pagination>
         </div>
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/src/pages/student/quizzes/QuizList/index.module.css
+++ b/src/pages/student/quizzes/QuizList/index.module.css
@@ -9,7 +9,8 @@
 }
 
 .container {
-  padding: 10px 0px;
+  margin: 0px 196px;
+  padding: 0px;
 }
 
 .backButton {
@@ -28,9 +29,9 @@
 
 #GridCard{
   display: grid;
-  grid-column-gap: 48px;
+  grid-column-gap: 46px;
   grid-row-gap: 48px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: 339px 339px 339px 339px;
   grid-template-rows: 216px 216px 216px;
   height: 747px;
   width: 1518px;


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-171
### Definition of Done
- [ ] Order of categories has space in the middle if items are even

### Commands to Run


### Notes
#### Main note

#### Pages Affected
- http://localhost:3003/categories
- http://localhost:3003/categories/1/sub
- http://localhost:3003/categories/1/quizzes

### Scenarios/ Test Cases
- [ ] it should order of categories has space in the middle if items are even
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![updatecategory](https://user-images.githubusercontent.com/89514595/143202553-e1465080-a983-4c20-a26c-3425a73db3cc.PNG)
![updatequiz](https://user-images.githubusercontent.com/89514595/143202561-119d3a5e-bc04-4950-8bc1-8c82db83cb16.PNG)
![updatesubcat](https://user-images.githubusercontent.com/89514595/143202573-de06c223-f18f-4f69-8252-5adf06a4c9a9.PNG)


