### PR TITLE
E_CLASSROOM-213 [FE/BE] Update display “Friend’s score” if empty

### DIFF
--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -105,6 +105,15 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                         </div>
                       );
                     })}
+                    {friendsScore?.length === 0 ? (
+                        <div>
+                          <center>
+                            <span>No Followed User</span>
+                          </center>
+                        </div>
+                      ) : (
+                        ''
+                      )}
                   </Card.Body>
                 </Card>
               </div>

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -106,14 +106,14 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                       );
                     })}
                     {friendsScore?.length === 0 ? (
-                        <div>
-                          <center>
-                            <span>No Followed User</span>
-                          </center>
-                        </div>
-                      ) : (
-                        ''
-                      )}
+                      <div>
+                        <center>
+                          <span>No Followed User</span>
+                        </center>
+                      </div>
+                    ) : (
+                      ''
+                    )}
                   </Card.Body>
                 </Card>
               </div>


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-213
### Definition of Done
- [x] User will see a text inside friend's score portion

### Commands to Run


### Notes
#### Main note
- 
#### Pages Affected
- User must take a quiz to see text in Friend's Score
- http://localhost:3003/categories/1/quizzes/1/questions

### Scenarios/ Test Cases
- [ ] User will see a text inside friend's score portion 
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![friendsScore](https://user-images.githubusercontent.com/89514595/146147362-a3f8c93c-ae86-4f5c-8299-d73355c36abe.PNG)

