### PR TITLE
E_CLASSROOM-216 [FE/BE] Dynamic User Data

### DIFF
--- a/src/pages/student/profile/ProfileDetail/index.js
+++ b/src/pages/student/profile/ProfileDetail/index.js
@@ -17,12 +17,14 @@ const ProfileDetail = () => {
   const ACTIVITY_TYPE = 'App\\Models\\Quiz';
 
   const [studentDetails, setStudentDetails] = useState(null);
+  const [overallQuizTaken, setOverallQuizTaken] = useState(0);
   const [friendsActivities, setFriendsActivities] = useState(null);
   const [recentActivities, setRecentActivities] = useState(null);
 
   useEffect(() => {
     StudentApi.getDetails(loggedInUserId).then(({ data }) => {
       setStudentDetails(data.details);
+      setOverallQuizTaken(data.quizzesTaken);
     });
 
     StudentApi.getRecentActivities(loggedInUserId).then(({ data }) => {
@@ -31,7 +33,6 @@ const ProfileDetail = () => {
 
     DashboardApi.getFriendsActivities().then(({ data }) => {
       setFriendsActivities(data.data);
-      console.log(data.data);
     });
   }, []);
 
@@ -69,10 +70,10 @@ const ProfileDetail = () => {
           </div>
 
           <div style={{ marginLeft: '40px' }}>
-            <div style={{ marginTop: '33px' }}>
+            <div style={{ marginTop: '33px' }} className={style.userInfo}>
               <div className={style.userEditText}>
                 <h2 style={{ fontSize: '32px', fontWeight: 'Bold' }}>
-                  Jane Doe
+                  {studentDetails?.name}
                 </h2>
                 <FaUserEdit size='40px' className={style.userEdit} />
               </div>
@@ -83,10 +84,16 @@ const ProfileDetail = () => {
                   color: '#48535B'
                 }}
               >
-                20 Total Quizzes Taken
+                {overallQuizTaken} Total Quizzes Taken
               </h4>
-              <p className={style.followersText}>10 Followers</p>
-              <p className={style.followingText}>10 Following</p>
+              <div>
+                <p className={style.followersText}>
+                  {studentDetails?.followers_count} Followers
+                </p>
+                <p className={style.followingText}>
+                  {studentDetails?.followings_count} Following
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/student/profile/ProfileDetail/index.module.css
+++ b/src/pages/student/profile/ProfileDetail/index.module.css
@@ -98,3 +98,9 @@
   margin-top: 20px;
   margin-left: 17px;
 }
+
+.userInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-216

### Definition of Done
- [x] Display dynamic total quizzes taken by the user
- [x] Dynamic user Followers and Following data

### Commands to Run
N/A
### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/profile

### Scenarios/ Test Cases
- [x] it should `show the logged in users name, the total number of quizzes taken and number of followers and following` when `the user visits their profile` 

### Screenshots
![image](https://user-images.githubusercontent.com/91049234/150502884-3b207474-8356-4c4d-bf7b-87cb5a0ed5bf.png)


