### PR TITLE
E_CLASSROOM-221 [Bugfix] Bonus Score is Added When Time Is Up

### DIFF
--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/index.js
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/index.js
@@ -28,6 +28,7 @@ const QuestionAnswer = () => {
   const [point, setPoint] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [submitStatus, setSubmitStatus] = useState(false);
+  const [timesUp, setTimesUp] = useState(false);
 
   const handleNextButtonClick = () => {
     setPrevPage(page);
@@ -100,6 +101,7 @@ const QuestionAnswer = () => {
         setTime(questions[page - 1]?.time_limit);
         setPage(page + 1);
       } else {
+        setTimesUp(true);
         storeLastAnswerAndGetTotalScore();
       }
     }
@@ -142,7 +144,6 @@ const QuestionAnswer = () => {
               question.question_type.question_type === 'Multiple Choice' ? (
                   <MultipleChoiceType
                     question={question}
-                    // page={page}
                     time={time}
                     getAnswer={getAnswer}
                     getPoint={getPoint}
@@ -150,7 +151,6 @@ const QuestionAnswer = () => {
                 ) : (
                   <FillInTheBlankType
                     question={question}
-                    // page={page}
                     time={time}
                     answer={textAnswer}
                     getAnswer={getAnswer}
@@ -166,9 +166,9 @@ const QuestionAnswer = () => {
                   <Button
                     id={style.nextBtn}
                     onClick={() => {
-                      submitStatus === false
-                        ? storeLastAnswerAndGetTotalScore()
-                        : '';
+                      submitStatus || timesUp
+                        ? ''
+                        : storeLastAnswerAndGetTotalScore();
 
                       setSubmitStatus(true);
                     }}


### PR DESCRIPTION
### Issue Link

### Definition of Done
- [x] Score should be exact and should not be added by one

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/categories/1/quizzes/1/questions

### Scenarios/ Test Cases
- [x] it should ` not add 1 to the actual score` when `time is already up and the user clicks the submit button` 

### Screenshots
![SCORE SHOULD NOT EXCEED THE TOTAL SCORE OR SHOULD NOT ADD BY ONE WHEN CLICKING THE SUBMIT BUTTON ONCE TIME IS UP](https://user-images.githubusercontent.com/91049234/150761624-ea2a4e49-c0da-4351-a5bb-be23f744d697.gif)
