### PR TITLE
E_CLASSROOM-226 [Bugfix] Remove Friend's Score UI If There's No Friends Score

### DIFF
--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -24,7 +24,6 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
     });
     FriendsScoreApi.getAll(quizId).then(({ data }) => {
       setFriendsScore(data.data);
-      console.log(data.data);
     });
   }, []);
 
@@ -37,29 +36,29 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
       {viewResults == false ? (
         <Container className={style.card}>
           <div>
-            <div className={style.Resulttopic}>{title}</div>
-            <Card.Body className={style.ResultwholeBodyCard}>
-              <div className={style.ResultupperBodyCard}>
-                <div className={style.ResultcardLeft}>
-                  <div className={style.ResultscoreDisplay}>
+            <div className={style.resultTopic}>{title}</div>
+            <Card.Body className={style.resultWholeBodyCard}>
+              <div className={style.resultUpperBodyCard}>
+                <div className={style.resultCardLeft}>
+                  <div className={style.resultScoreDisplay}>
                     {score < passing ? (
                       <>
-                        <div className={style.ResultquizPraise}>
+                        <div className={style.resultQuizPraise}>
                           Better Luck Next Time!
                         </div>
-                        <div className={style.ResultquizRemarks}>
+                        <div className={style.resultQuizRemarks}>
                           You Failed
                         </div>
                       </>
                     ) : (
                       <>
-                        <div className={style.ResultquizPraise}>Great Job!</div>
-                        <div className={style.ResultquizRemarks}>
+                        <div className={style.resultQuizPraise}>Great Job!</div>
+                        <div className={style.resultQuizRemarks}>
                           You Passed
                         </div>
                       </>
                     )}
-                    <Card.Text className={style.Resultscore}>
+                    <Card.Text className={style.resultScore}>
                       {' '}
                       <span
                         className={
@@ -72,64 +71,63 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                     </Card.Text>
                   </div>
                 </div>
-                <Card className={style.Resultcard2}>
-                  <Card.Header className={style.friendsTitle}>
-                    <div className={style.texttittlestyle}>
-                      Friend&apos;s Score
-                    </div>
-                    <hr className={style.hrstyle} />
-                  </Card.Header>
-                  <Card.Body className={style.cardbodystyle}>
-                    {friendsScore?.map((friendScore, idx) => {
-                      return (
-                        <div key={idx}>
-                          <div className={style.friendsScore}>
-                            {friendScore.score}/{total}
-                          </div>
-                          <Link to={`/students/${friendScore.id}`}>
-                            <tr>
-                              <td>
-                                {friendScore.avatar === null ? (
-                                  <div>
-                                    <img
-                                      className={style.ResultsizeOfAvatar}
-                                      alt="avatar"
-                                      src="https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png"
-                                    />
-                                  </div>
-                                ) : (
-                                  <div>
-                                    <img
-                                      className={style.ResultsizeOfAvatar}
-                                      alt="avatar"
-                                      src={friendScore.avatar}
-                                    />
-                                  </div>
-                                )}
-                              </td>
-                              <td className={style.friendsName}>
+                {friendsScore?.length > 0 ? (
+                  <Card className={style.friendsScoreCard}>
+                    <Card.Header className={style.friendsTitle}>
+                      <div className={style.friendsScoreText}>
+                        Friend&apos;s Score
+                      </div>
+                      <hr className={style.divider} />
+                    </Card.Header>
+                    <Card.Body className={style.friendsScoreCardBody}>
+                      {friendsScore?.map((friendScore, idx) => {
+                        return (
+                          <div key={idx}>
+                            <Link
+                              to={`/students/${friendScore.id}`}
+                              className={style.friendsScoreInfo}
+                            >
+                              <div>
+                                <img
+                                  className={style.friendsAvatar}
+                                  alt="avatar"
+                                  src={
+                                    friendScore.avatar === null
+                                      ? 'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
+                                      : friendScore.avatar
+                                  }
+                                />
+                              </div>
+
+                              <div className={style.friendsName}>
                                 {friendScore.name}
-                              </td>
-                            </tr>
-                          </Link>
-                        </div>
-                      );
-                    })}
-                  </Card.Body>
-                </Card>
+                              </div>
+
+                              <div className={style.friendsScore}>
+                                {friendScore.score}/{total}
+                              </div>
+                            </Link>
+                          </div>
+                        );
+                      })}
+                    </Card.Body>
+                  </Card>
+                ) : (
+                  ''
+                )}
               </div>
-              <hr className={style.ResulthrBreakButtom} />
-              <div className={style.ResultbottomBodyCard}>
+              <hr className={style.resultsCardDivider} />
+              <div className={style.resultsButtons}>
                 <Button
                   onClick={() => viewResultsPage()}
-                  id={style.ResultviewResultBtn}
+                  id={style.viewResultsButton}
                 >
                   View Result
                 </Button>
                 <a
                   href={`/categories/${categoryId}/quizzes/${quizId}/questions`}
                 >
-                  <Button id={style.ResultretakeBtn}>Retake Quiz</Button>
+                  <Button id={style.retakeButton}>Retake Quiz</Button>
                 </a>
               </div>
             </Card.Body>
@@ -137,8 +135,8 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
           <div>
             <footer>
               <div>
-                <h2 className={style.h2_style}>Related Quizzes</h2>
-                <div className={style.bg}>
+                <h2 className={style.relatedQuizzesText}>Related Quizzes</h2>
+                <div className={style.relatedQuizzes}>
                   <Recent title="HTML" />
                   <Recent title="Linked List" />
                   <Recent title="Encapsulation" />

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -92,9 +92,8 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                                   className={style.friendsAvatar}
                                   alt="avatar"
                                   src={
-                                    friendScore.avatar === null
-                                      ? 'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
-                                      : friendScore.avatar
+                                    friendScore.avatar ||
+                                    'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
                                   }
                                 />
                               </div>

--- a/src/pages/student/quizzes/QuizResult/index.module.css
+++ b/src/pages/student/quizzes/QuizResult/index.module.css
@@ -92,12 +92,12 @@
 }
 
 .friendsScore {
+  margin-left: auto;
   font-size: 16px;
   color: #48535b;
 }
 
 .friendsName {
-  align-self: center;
   padding: 10px 10px 10px 5px;
   font-size: 16px;
   color: #48535b;
@@ -174,7 +174,7 @@
 }
 
 .friendsScoreCardBody {
-  padding: 0px;
+  padding: 0px 15px;
 }
 
 .divider {
@@ -189,7 +189,7 @@
 
 .friendsScoreInfo {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
 }
 

--- a/src/pages/student/quizzes/QuizResult/index.module.css
+++ b/src/pages/student/quizzes/QuizResult/index.module.css
@@ -192,12 +192,3 @@
   justify-content: flex-start;
   align-items: center;
 }
-
-.noFriendsScoreMessage {
-  background-color: #f5f5f5f5;
-  color: #48535b;
-  border-radius: 5px;
-  text-align: center;
-  padding: 10px;
-  margin: 55px 15px;
-}

--- a/src/pages/student/quizzes/QuizResult/index.module.css
+++ b/src/pages/student/quizzes/QuizResult/index.module.css
@@ -1,7 +1,3 @@
-.centerWord {
-  margin-top: 95px;
-}
-
 .card {
   align-items: center;
   flex-direction: column;
@@ -10,96 +6,63 @@
   margin-top: 52px;
 }
 
-.bg {
+.relatedQuizzes {
   display: flex;
   justify-content: space-between;
   margin-bottom: 33px;
 }
 
-.h2_style {
-  padding: 33px 0px 33px 0px;
+.relatedQuizzesText {
+  padding: 33px 30px;
 }
 
-.Resultparagraph {
-  font-size: 16px;
-  margin: 0;
-  padding: 10px;
-  justify-content: center;
-}
-
-.ResulthrBreakBottom {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.5);
-}
-
-.ResulthrBreak {
-  margin: 10px 0px 0px 0px;
-  color: rgba(0, 0, 0, 0.5);
-}
-
-.ResultwholeBodyCard {
+.resultWholeBodyCard {
   height: 424px;
   width: 674px;
   background-color: white;
 }
 
-.Resulttml {
-  width: 333px;
-  height: 69px;
-  color: black;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-}
-
-.Resulttimer {
-  padding: 13px;
-  color: #c30101;
-  opacity: 50%;
-  background-color: #c4c4c4;
-}
-
-.ResultupperBodyCard {
+.resultUpperBodyCard {
   margin-top: 10px;
   display: flex;
   justify-content: center;
 }
 
-.ResultcardLeft {
+.resultCardLeft {
   justify-content: center;
   display: flex;
   width: 424px;
   padding: 20px;
 }
 
-.ResultscoreDisplay {
+.resultScoreDisplay {
   width: 300px;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.ResultquizPraise {
+.resultQuizPraise {
   font-weight: normal;
   font-size: 28px;
   margin-bottom: 20px;
   color: #48535b;
 }
 
-.ResultquizRemarks {
+.resultQuizRemarks {
   font-weight: bold;
   font-size: 36px;
   margin-bottom: 20px;
   color: #48535b;
 }
 
-.Resultscore {
+.resultScore {
   font-size: 72px;
 }
 
-#ResultviewResultBtn {
+#viewResultsButton {
   font-size: 14px;
   margin-right: 1rem;
-  justify-content: end;
   width: 120px;
   height: 36px;
   border-radius: 0px;
@@ -108,7 +71,7 @@
   color: black;
 }
 
-#ResultviewResultBtn:hover {
+#viewResultsButton:hover {
   background-color: #9abec1;
   color: white;
 }
@@ -129,11 +92,8 @@
 }
 
 .friendsScore {
-  padding: 0px 0px 0px 0px;
   font-size: 16px;
-  margin-left: 180px;
-  position: absolute;
-  margin-top: 10px;
+  color: #48535b;
 }
 
 .friendsName {
@@ -147,21 +107,25 @@
   color: #000000;
 }
 
-.Resultcard2 {
+.friendsScoreCard {
   border: 1px solid rgba(0, 0, 0, 0.164);
   width: 225px;
   height: 272px;
   border-radius: 5px;
 }
 
-.ResultbottomBodyCard {
-  height: 85px;
+.resultsCardDivider {
+  margin-top: 25px;
+}
+
+.resultsButtons {
+  height: 65px;
   display: flex;
   justify-content: end;
   align-items: center;
 }
 
-#ResultretakeBtn {
+#retakeButton {
   width: 120px;
   height: 36px;
   justify-content: end;
@@ -172,13 +136,9 @@
   font-size: 14px;
 }
 
-#ResultretakeBtn:hover {
+#retakeButton:hover {
   background-color: #9abec1;
   color: white;
-}
-
-.ResultnumItems {
-  font-size: 30px;
 }
 
 .pass {
@@ -189,7 +149,7 @@
   color: red;
 }
 
-.Resulttopic {
+.resultTopic {
   margin: 0;
   padding: 10px;
   text-align: center;
@@ -206,63 +166,38 @@
   color: #48535b;
 }
 
-.ResultrelatedQuizzes {
-  font-size: 25px;
-  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-}
-
-.ResultfooterCard {
-  width: 1296px;
-  height: 193px;
-  margin-right: 2rem;
-  justify-content: space-between;
-  background-color: rgba(128, 128, 128, 10%);
-  border-radius: 15px;
-}
-
-.Resultfooter {
-  padding-top: 28px;
-  display: center;
-}
-
-.ResultfooterCardContainer:hover {
-  background-color: rgb(121, 163, 156);
-}
-
-.ResultsizeOfAvatar {
+.friendsAvatar {
   width: 30px;
   height: 30px;
   border-radius: 30px;
   margin-right: 10px;
 }
 
-.ResultsizeOfAvatarFooter {
-  height: 50px;
-  margin-right: 20px;
-  margin-bottom: 10px;
+.friendsScoreCardBody {
+  padding: 0px;
 }
 
-.spanForTimeLeft {
-  color: black;
-  font-weight: 400;
-  margin-top: 15px;
-}
-
-.cardbodystyle {
-  padding-top: 0px;
-  padding-right: 0px;
-}
-
-.hrstyle {
+.divider {
   width: 200px;
   margin-bottom: 0px;
   margin-top: 10px;
 }
 
-.texttittlestyle {
+.friendsScoreText {
   margin-left: 45px;
 }
 
-.divstylecard {
+.friendsScoreInfo {
   display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.noFriendsScoreMessage {
+  background-color: #f5f5f5f5;
+  color: #48535b;
+  border-radius: 5px;
+  text-align: center;
+  padding: 10px;
+  margin: 55px 15px;
 }


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-226

### Definition of Done
- [x] There should be no Friend's Score section in the Quiz Results page when there are no friend's scores.

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/categories/7/quizzes/7/questions

### Scenarios/ Test Cases
- [x] There should be `no Friend's Score section` when `the friend's score list is empty` 

### Screenshots
![image](https://user-images.githubusercontent.com/91049234/151105030-002dc922-f333-4a9b-95d0-b8d55ffb3d43.png)
