### PR TITLE
E_CLASSROOM-241 [Admin] FE Implement Admin Login

### DIFF
--- a/src/api/Auth/index.js
+++ b/src/api/Auth/index.js
@@ -5,7 +5,7 @@ const AuthApi = {
     const options = {
       method: 'GET',
       url: '/user',
-      params: { ...params },
+      params: { ...params }
     };
 
     return API.request(options);
@@ -20,21 +20,22 @@ const AuthApi = {
         name: name,
         email: email,
         password: password,
-        password_confirmation: password_confirmation,
-      },
+        password_confirmation: password_confirmation
+      }
     };
 
     return API.request(options);
   },
 
-  login: ({ email, password }) => {
+  login: ({ email, password, loginType }) => {
     const options = {
       method: 'POST',
       url: '/login',
       data: {
         email: email,
         password: password,
-      },
+        loginType: loginType
+      }
     };
 
     return API.request(options);
@@ -44,7 +45,7 @@ const AuthApi = {
     const options = {
       method: 'POST',
       url: '/logout',
-      data: {},
+      data: {}
     };
 
     return API.request(options);
@@ -55,8 +56,8 @@ const AuthApi = {
       method: 'POST',
       url: '/forgot-password',
       data: {
-        email: email,
-      },
+        email: email
+      }
     };
 
     return API.request(options);
@@ -70,12 +71,12 @@ const AuthApi = {
         email: email,
         password: password,
         password_confirmation: password_confirmation,
-        token: token,
-      },
+        token: token
+      }
     };
 
     return API.request(options);
-  },
+  }
 };
 
 export default AuthApi;

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -13,9 +13,10 @@ import AuthApi from '../../../../api/Auth';
 
 const AdminLogin = () => {
   const { control, handleSubmit } = useForm();
-  const [errors, setErrors] = useState('');
+  const [error, setError] = useState('');
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
+  const [submitStatus, setSubmitStatus] = useState(false);
 
   const showAlertDialog = (isShow, message) => {
     setShowAlert(isShow);
@@ -23,6 +24,10 @@ const AdminLogin = () => {
   };
 
   const handleOnSubmit = async ({ email, password }) => {
+    setSubmitStatus(true);
+    setError('');
+    setShowAlert(false);
+
     try {
       const response = await AuthApi.login({ email, password, loginType: 'Admin' });
       Cookies.set('access_token', response.data.token);
@@ -30,8 +35,9 @@ const AdminLogin = () => {
       Cookies.set('user_type', 'admin');
       window.location = '/admin/categories';
     } catch (error) {
+      setSubmitStatus(false);
       if (error?.response?.data?.error?.error) {
-        setErrors(error?.response?.data?.error?.error);
+        setError(error?.response?.data?.error?.error);
         showAlertDialog(true, error?.response?.data?.error?.error);
       } else {
         showAlertDialog(true, 'An error has occurred.');
@@ -69,13 +75,13 @@ const AdminLogin = () => {
                         ref={ref}
                         type="email"
                         placeholder="Enter email here"
-                        isInvalid={errors === 'The password you’ve entered is incorrect.' ? '' : errors}
+                        isInvalid={error === 'The password you’ve entered is incorrect.' ? '' : error}
                         required
                         maxLength={50}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
                 </Form.Group>
 
                 <Form.Group className="mb-1" controlId="password">
@@ -94,17 +100,17 @@ const AdminLogin = () => {
                         type="password"
                         name="password"
                         placeholder="Enter password here"
-                        isInvalid={errors === 'The email you’ve entered is incorrect.' ? '' : errors}
+                        isInvalid={error === 'The email you’ve entered is incorrect.' ? '' : error}
                         required
                         maxLength={20}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
                 </Form.Group>
 
                 <center>
-                  <Button id={style.signInButton} type="submit">
+                  <Button id={style.signInButton} type="submit" disabled={submitStatus}>
                     <p>Sign In</p>
                   </Button>
                 </center>

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -13,7 +13,7 @@ import AuthApi from '../../../../api/Auth';
 
 const AdminLogin = () => {
   const { control, handleSubmit } = useForm();
-  const [error, setError] = useState('');
+  const [error, setError] = useState({});
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
   const [submitStatus, setSubmitStatus] = useState(false);
@@ -36,9 +36,9 @@ const AdminLogin = () => {
       window.location = '/admin/categories';
     } catch (error) {
       setSubmitStatus(false);
-      if (error?.response?.data?.error?.error) {
-        setError(error?.response?.data?.error?.error);
-        showAlertDialog(true, error?.response?.data?.error?.error);
+      if (error?.response?.data?.error) {
+        setError(error?.response?.data?.error);
+        showAlertDialog(true, error?.response?.data?.error?.unauthorized || 'Incorrect Credentials');
       } else {
         showAlertDialog(true, 'An error has occurred.');
       }
@@ -75,13 +75,13 @@ const AdminLogin = () => {
                         ref={ref}
                         type="email"
                         placeholder="Enter email here"
-                        isInvalid={error === 'The password you’ve entered is incorrect.' ? '' : error}
+                        isInvalid={!!error?.email || !!error?.unauthorized}
                         required
                         maxLength={50}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error?.email || error?.unauthorized}</Form.Control.Feedback>
                 </Form.Group>
 
                 <Form.Group className="mb-1" controlId="password">
@@ -100,13 +100,13 @@ const AdminLogin = () => {
                         type="password"
                         name="password"
                         placeholder="Enter password here"
-                        isInvalid={error === 'The email you’ve entered is incorrect.' ? '' : error}
+                        isInvalid={!!error?.password}
                         required
                         maxLength={20}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{error}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error?.password}</Form.Control.Feedback>
                 </Form.Group>
 
                 <center>

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -1,7 +1,120 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import Cookies from 'js-cookie';
+import Button from 'react-bootstrap/Button';
+import Alert from 'react-bootstrap/Alert';
+import Container from 'react-bootstrap/Container';
+import Stack from 'react-bootstrap/Stack';
+import Form from 'react-bootstrap/Form';
 
-const Login = () => {
-  return <div></div>;
+import style from './index.module.css';
+
+import AuthApi from '../../../../api/Auth';
+
+const AdminLogin = () => {
+  const { control, handleSubmit } = useForm();
+  const [errors, setErrors] = useState('');
+  const [showAlert, setShowAlert] = useState(false);
+  const [alertMessage, setAlertMessage] = useState('');
+
+  const showAlertDialog = (isShow, message) => {
+    setShowAlert(isShow);
+    setAlertMessage(message);
+  };
+
+  const handleOnSubmit = async ({ email, password }) => {
+    try {
+      const response = await AuthApi.login({ email, password, loginType: 'Admin' });
+      Cookies.set('access_token', response.data.token);
+      Cookies.set('admin_id', response.data.user.id);
+      Cookies.set('user_type', 'admin');
+      window.location = '/admin/profile';
+    } catch (error) {
+      if (error?.response?.data?.error?.error) {
+        setErrors(error?.response?.data?.error?.error);
+        showAlertDialog(true, error?.response?.data?.error?.error);
+      } else {
+        showAlertDialog(true, 'An error has occurred.');
+      }
+    }
+  };
+
+  return (
+    <div className="d-flex justify-content-center align-items-center">
+      {showAlert && (
+        <Alert className={`${style.alert}`} variant="danger" onClose={() => setShowAlert(false)} dismissible>
+          {alertMessage}
+        </Alert>
+      )}
+      <div>
+        <Container className={style.loginContainer}>
+          <Stack gap={2} id={style.loginForm}>
+            <div className={style.signInText}>
+              <h4>Sign In</h4>
+            </div>
+            <Form onSubmit={handleSubmit(handleOnSubmit)}>
+              <div className={style.contanair}>
+                <Form.Group className="mb-3" controlId="email">
+                  <Form.Label>
+                    <h6 className="mb-0">Email Address</h6>
+                  </Form.Label>
+                  <Controller
+                    control={control}
+                    name="email"
+                    defaultValue=""
+                    render={({ field: { onChange, value, ref } }) => (
+                      <Form.Control
+                        onChange={onChange}
+                        value={value}
+                        ref={ref}
+                        type="email"
+                        placeholder="Enter email here"
+                        isInvalid={errors === 'The password you’ve entered is incorrect.' ? '' : errors}
+                        required
+                        maxLength={50}
+                      />
+                    )}
+                  />
+                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                </Form.Group>
+
+                <Form.Group className="mb-1" controlId="password">
+                  <Form.Label>
+                    <h6 className="mb-0 mt-3">Password</h6>
+                  </Form.Label>
+                  <Controller
+                    control={control}
+                    name="password"
+                    defaultValue=""
+                    render={({ field: { onChange, value, ref } }) => (
+                      <Form.Control
+                        onChange={onChange}
+                        value={value}
+                        ref={ref}
+                        type="password"
+                        name="password"
+                        placeholder="Enter password here"
+                        isInvalid={errors === 'The email you’ve entered is incorrect.' ? '' : errors}
+                        required
+                        maxLength={20}
+                      />
+                    )}
+                  />
+                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                </Form.Group>
+
+                <center>
+                  <Button id={style.signInButton} type="submit">
+                    <p>Sign In</p>
+                  </Button>
+                </center>
+              </div>
+            </Form>
+          </Stack>
+        </Container>
+      </div>
+    </div>
+  );
 };
 
-export default Login;
+export default AdminLogin;

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -28,7 +28,7 @@ const AdminLogin = () => {
       Cookies.set('access_token', response.data.token);
       Cookies.set('admin_id', response.data.user.id);
       Cookies.set('user_type', 'admin');
-      window.location = '/admin/profile';
+      window.location = '/admin/categories';
     } catch (error) {
       if (error?.response?.data?.error?.error) {
         setErrors(error?.response?.data?.error?.error);

--- a/src/pages/admin/main/Login/index.module.css
+++ b/src/pages/admin/main/Login/index.module.css
@@ -16,7 +16,7 @@
 .signInText {
   height: 45px;
   align-self: center;
-  font-weight: 400px;
+  font-weight: 400;
   color: #48535b;
 }
 

--- a/src/pages/admin/main/Login/index.module.css
+++ b/src/pages/admin/main/Login/index.module.css
@@ -1,0 +1,44 @@
+.loginContainer {
+  margin-top: 200px;
+}
+
+#loginForm {
+  background-color: #e0eaec;
+  color: #48535b;
+  display: flex;
+  justify-content: space-evenly;
+  padding: 48px 48px;
+  border-radius: 2px;
+  height: auto;
+  width: 430px;
+}
+
+.signInText {
+  height: 45px;
+  align-self: center;
+  font-weight: 400px;
+  color: #48535b;
+}
+
+#signInButton {
+  background-color: #c0d5d8;
+  border-color: #c0d5d8;
+  color: #48535b;
+  margin-top: 25px;
+  font-size: 14px;
+  width: 85px;
+  height: 32px;
+}
+
+#signInButton:hover {
+  background-color: #9abec1;
+  border-color: #9abec1;
+  color: white;
+}
+
+.alert {
+  position: fixed;
+  top: 100px;
+  width: 430px;
+  color: #48535b;
+}

--- a/src/pages/student/main/Login/index.js
+++ b/src/pages/student/main/Login/index.js
@@ -11,9 +11,10 @@ import AuthApi from '../../../../api/Auth';
 
 const Login = () => {
   const { control, handleSubmit } = useForm();
-  const [errors, setErrors] = useState('');
+  const [error, setError] = useState({});
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
+  const [submitStatus, setSubmitStatus] = useState(false);
 
   const showAlertDialog = (isShow, message) => {
     setShowAlert(isShow);
@@ -21,6 +22,10 @@ const Login = () => {
   };
 
   const handleOnSubmit = async ({ email, password }) => {
+    setSubmitStatus(true);
+    setError('');
+    setShowAlert(false);
+
     try {
       const response = await AuthApi.login({ email, password, loginType: 'Student' });
       Cookies.set('access_token', response.data.token);
@@ -28,9 +33,10 @@ const Login = () => {
       Cookies.set('user_type', 'student');
       window.location = '/';
     } catch (error) {
-      if (error?.response?.data?.error?.error) {
-        setErrors(error?.response?.data?.error?.error);
-        showAlertDialog(true, error?.response?.data?.error?.error);
+      setSubmitStatus(false);
+      if (error?.response?.data?.error) {
+        setError(error?.response?.data?.error);
+        showAlertDialog(true, error?.response?.data?.error?.unauthorized || 'Incorrect Credentials');
       } else {
         showAlertDialog(true, 'An error has occurred.');
       }
@@ -68,13 +74,13 @@ const Login = () => {
                         ref={ref}
                         type="email"
                         placeholder="Enter here"
-                        isInvalid={errors === 'The password you’ve entered is incorrect.' ? '' : errors}
+                        isInvalid={!!error?.email || !!error?.unauthorized}
                         required
                         maxLength={50}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error?.email || error?.unauthorized}</Form.Control.Feedback>
                 </Form.Group>
 
                 <Form.Group className="mb-1" controlId="password">
@@ -93,13 +99,13 @@ const Login = () => {
                         type="password"
                         name="password"
                         placeholder="Enter here"
-                        isInvalid={errors === 'The email you’ve entered is incorrect.' ? '' : errors}
+                        isInvalid={!!error?.password}
                         required
                         maxLength={20}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{error?.password}</Form.Control.Feedback>
                 </Form.Group>
 
                 <p>
@@ -111,7 +117,7 @@ const Login = () => {
                 </p>
 
                 <center>
-                  <Button id={style.Btncolor} type="submit">
+                  <Button id={style.Btncolor} type="submit" disabled={submitStatus}>
                     <p style={{ fontSize: '14px' }}>Sign In</p>
                   </Button>
                 </center>

--- a/src/pages/student/main/Login/index.js
+++ b/src/pages/student/main/Login/index.js
@@ -22,14 +22,15 @@ const Login = () => {
 
   const handleOnSubmit = async ({ email, password }) => {
     try {
-      const response = await AuthApi.login({ email, password });
+      const response = await AuthApi.login({ email, password, loginType: 'Student' });
       Cookies.set('access_token', response.data.token);
       Cookies.set('user_id', response.data.user.id);
+      Cookies.set('user_type', 'student');
       window.location = '/';
     } catch (error) {
       if (error?.response?.data?.error?.error) {
         setErrors(error?.response?.data?.error?.error);
-        showAlertDialog(true, 'Incorrect Credentials');
+        showAlertDialog(true, error?.response?.data?.error?.error);
       } else {
         showAlertDialog(true, 'An error has occurred.');
       }
@@ -39,12 +40,7 @@ const Login = () => {
   return (
     <div className="d-flex justify-content-center align-items-center">
       {showAlert && (
-        <Alert
-          className={`${style.alert}`}
-          variant="danger"
-          onClose={() => setShowAlert(false)}
-          dismissible
-        >
+        <Alert className={`${style.alert}`} variant="danger" onClose={() => setShowAlert(false)} dismissible>
           {alertMessage}
         </Alert>
       )}
@@ -72,26 +68,18 @@ const Login = () => {
                         ref={ref}
                         type="email"
                         placeholder="Enter here"
-                        isInvalid={
-                          errors === 'The password you’ve entered is incorrect.'
-                            ? ''
-                            : errors
-                        }
+                        isInvalid={errors === 'The password you’ve entered is incorrect.' ? '' : errors}
                         required
                         maxLength={50}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">
-                    {errors}
-                  </Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
                 </Form.Group>
 
                 <Form.Group className="mb-1" controlId="password">
                   <Form.Label>
-                    <h6 style={{ marginBottom: '0px', marginTop: '10px' }}>
-                      Password
-                    </h6>
+                    <h6 style={{ marginBottom: '0px', marginTop: '10px' }}>Password</h6>
                   </Form.Label>
                   <Controller
                     control={control}
@@ -105,28 +93,18 @@ const Login = () => {
                         type="password"
                         name="password"
                         placeholder="Enter here"
-                        isInvalid={
-                          errors === 'The email you’ve entered is incorrect.'
-                            ? ''
-                            : errors
-                        }
+                        isInvalid={errors === 'The email you’ve entered is incorrect.' ? '' : errors}
                         required
                         maxLength={20}
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">
-                    {errors}
-                  </Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">{errors}</Form.Control.Feedback>
                 </Form.Group>
 
                 <p>
                   <LinkContainer to="/reset-password">
-                    <a
-                      className={style.forgotPswrdsize}
-                      style={{ textDecoration: 'none', marginTop: '0px' }}
-                      href="/#"
-                    >
+                    <a className={style.forgotPswrdsize} style={{ textDecoration: 'none', marginTop: '0px' }} href="/#">
                       Forgot password?
                     </a>
                   </LinkContainer>
@@ -143,11 +121,7 @@ const Login = () => {
                     <p className={style.sign}>No Account Yet?</p>
                     <h5 className={style.sign}>
                       <LinkContainer to="/registration">
-                        <a
-                          className={style.forgotPswrd}
-                          style={{ textDecoration: 'none' }}
-                          href="/#"
-                        >
+                        <a className={style.forgotPswrd} style={{ textDecoration: 'none' }} href="/#">
                           Sign Up
                         </a>
                       </LinkContainer>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,17 +1,14 @@
 import React from 'react';
-import {
-  Switch,
-  withRouter,
-  // Route
-} from 'react-router-dom';
+import { Switch, withRouter } from 'react-router-dom';
 
 // Middleware Route Components
 import AdminRoute from './middleware/AdminRoute';
 import StudentRoute from './middleware/StudentRoute';
 import AuthRoute from './middleware/AuthRoute';
 
-// Admin Components
-import admin from '../pages/admin/categories/CategoryList';
+//Admin Components
+import AdminLogin from '../pages/admin/main/Login';
+import CategoryList from '../pages/admin/categories/CategoryList';
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -19,7 +16,6 @@ import Registration from '../pages/student/main/Registration';
 import forgotPassword from '../pages/student/main/PasswordReset';
 import NewPassword from '../pages/student/main/NewPassword';
 import ProfileDetail from '../pages/student/profile/ProfileDetail';
-// import Home from '../pages/student/main/Home';
 import Dashboard from '../pages/student/main/Dashboard';
 import CategoryList from '../pages/student/categories/CategoryList';
 import CategoryDetail from '../pages/student/categories/CategoryDetail';
@@ -39,93 +35,31 @@ const Routes = () => {
   return (
     <Switch>
       {/* ADMIN ROUTES */}
-      <AdminRoute path="/admin" exact component={admin}></AdminRoute>
+      <AuthRoute path="/admin/login" exact component={AdminLogin}></AuthRoute>
+
+      <AdminRoute path="/admin/categories" exact component={CategoryList}></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>
-      <AuthRoute
-        path="/registration"
-        exact
-        component={Registration}
-      ></AuthRoute>
-      <AuthRoute
-        path="/reset-password"
-        exact
-        component={forgotPassword}
-      ></AuthRoute>
+      <AuthRoute path="/registration" exact component={Registration}></AuthRoute>
+      <AuthRoute path="/reset-password" exact component={forgotPassword}></AuthRoute>
       <AuthRoute path="/new-password" exact component={NewPassword}></AuthRoute>
-      {/* <StudentRoute path="/" exact component={Home}></StudentRoute> */}
-      <StudentRoute
-        path="/profile"
-        exact
-        component={ProfileDetail}
-      ></StudentRoute>
+
+      <StudentRoute path="/profile" exact component={ProfileDetail}></StudentRoute>
       <StudentRoute path="/" exact component={Dashboard}></StudentRoute>
-      <StudentRoute
-        path="/students"
-        exact
-        component={StudentList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/learnings"
-        exact
-        component={LearningList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories"
-        exact
-        component={CategoryList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:id/sub"
-        exact
-        component={CategoryDetail}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:id/quizzes"
-        exact
-        component={QuizList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:categoryId/quizzes/:quizId/questions"
-        exact
-        component={QuestionList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:categoryId/quizzes/:quizId/questions/:questionId/answer"
-        exact
-        component={QuestionAnswer}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:id/quizzes/:id/results"
-        exact
-        component={QuizResult}
-      ></StudentRoute>
-      <StudentRoute
-        path="/categories/:id/quizzes/:id/results/:id/answer-result"
-        exact
-        component={QuizAnswerResult}
-      ></StudentRoute>
-      <StudentRoute
-        path="/profile/change-password"
-        exact
-        component={ChangePassword}
-      ></StudentRoute>
-      <StudentRoute
-        path="/profile/view"
-        exact
-        component={ProfileView}
-      ></StudentRoute>
-      <StudentRoute
-        path="/profile/edit"
-        exact
-        component={ProfileEdit}
-      ></StudentRoute>
-      <StudentRoute
-        path="/students/:id"
-        exact
-        component={StudentDetails}
-      ></StudentRoute>
+      <StudentRoute path="/students" exact component={StudentList}></StudentRoute>
+      <StudentRoute path="/learnings" exact component={LearningList}></StudentRoute>
+      <StudentRoute path="/categories" exact component={CategoryList}></StudentRoute>
+      <StudentRoute path="/categories/:id/sub" exact component={CategoryDetail}></StudentRoute>
+      <StudentRoute path="/categories/:id/quizzes" exact component={QuizList}></StudentRoute>
+      <StudentRoute path="/categories/:categoryId/quizzes/:quizId/questions" exact component={QuestionList}></StudentRoute>
+      <StudentRoute path="/categories/:categoryId/quizzes/:quizId/questions/:questionId/answer" exact component={QuestionAnswer}></StudentRoute>
+      <StudentRoute path="/categories/:id/quizzes/:id/results" exact component={QuizResult}></StudentRoute>
+      <StudentRoute path="/categories/:id/quizzes/:id/results/:id/answer-result" exact component={QuizAnswerResult}></StudentRoute>
+      <StudentRoute path="/profile/change-password" exact component={ChangePassword}></StudentRoute>
+      <StudentRoute path="/profile/view" exact component={ProfileView}></StudentRoute>
+      <StudentRoute path="/profile/edit" exact component={ProfileEdit}></StudentRoute>
+      <StudentRoute path="/students/:id" exact component={StudentDetails}></StudentRoute>
 
       {/* ERROR ROUTES */}
     </Switch>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,7 +8,7 @@ import AuthRoute from './middleware/AuthRoute';
 
 //Admin Components
 import AdminLogin from '../pages/admin/main/Login';
-import CategoryList from '../pages/admin/categories/CategoryList';
+import AdminCategoryList from '../pages/admin/categories/CategoryList';
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -37,7 +37,7 @@ const Routes = () => {
       {/* ADMIN ROUTES */}
       <AuthRoute path="/admin/login" exact component={AdminLogin}></AuthRoute>
 
-      <AdminRoute path="/admin/categories" exact component={CategoryList}></AdminRoute>
+      <AdminRoute path="/admin/categories" exact component={AdminCategoryList}></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>

--- a/src/routes/middleware/AdminRoute/index.js
+++ b/src/routes/middleware/AdminRoute/index.js
@@ -15,17 +15,17 @@ const AdminRoute = ({ component: Component, ...rest }) => {
       <Route
         {...rest}
         render={(props) => {
-          if (AuthService.authenticated()) {
+          if (AuthService.authenticated() && AuthService.isAdmin()) {
             return <Component {...props} />;
           }
 
           return (
             <Redirect
               to={{
-                pathname: '/login',
+                pathname: AuthService.isAdmin() ? '/admin/login' : '/login',
                 state: {
-                  from: props.location,
-                },
+                  from: props.location
+                }
               }}
             />
           );
@@ -38,7 +38,7 @@ const AdminRoute = ({ component: Component, ...rest }) => {
 AdminRoute.propTypes = {
   component: PropTypes.any,
   name: PropTypes.string,
-  location: PropTypes.any,
+  location: PropTypes.any
 };
 
 export default AdminRoute;

--- a/src/routes/middleware/AuthRoute/index.js
+++ b/src/routes/middleware/AuthRoute/index.js
@@ -19,14 +19,13 @@ const AuthRoute = ({ component: Component, ...rest }) => {
           if (!AuthService.authenticated()) {
             return <Component {...props} />;
           }
-
           return (
             <Redirect
               to={{
-                pathname: '/',
+                pathname: AuthService.isAdmin() ? '/admin/profile' : '/',
                 state: {
-                  from: props.location,
-                },
+                  from: props.location
+                }
               }}
             />
           );
@@ -39,8 +38,7 @@ const AuthRoute = ({ component: Component, ...rest }) => {
 AuthRoute.propTypes = {
   component: PropTypes.any,
   name: PropTypes.string,
-  location: PropTypes.any,
+  location: PropTypes.any
 };
-
 
 export default AuthRoute;

--- a/src/routes/middleware/AuthRoute/index.js
+++ b/src/routes/middleware/AuthRoute/index.js
@@ -22,7 +22,7 @@ const AuthRoute = ({ component: Component, ...rest }) => {
           return (
             <Redirect
               to={{
-                pathname: AuthService.isAdmin() ? '/admin/profile' : '/',
+                pathname: AuthService.isAdmin() ? '/admin/categories' : '/',
                 state: {
                   from: props.location
                 }

--- a/src/routes/middleware/StudentRoute/index.js
+++ b/src/routes/middleware/StudentRoute/index.js
@@ -15,17 +15,17 @@ const StudentRoute = ({ component: Component, ...rest }) => {
       <Route
         {...rest}
         render={(props) => {
-          if (AuthService.authenticated()) {
+          if (AuthService.authenticated() && !AuthService.isAdmin()) {
             return <Component {...props} />;
           }
 
           return (
             <Redirect
               to={{
-                pathname: '/login',
+                pathname: AuthService.isAdmin() ? '/admin/login' : '/login',
                 state: {
-                  from: props.location,
-                },
+                  from: props.location
+                }
               }}
             />
           );
@@ -38,8 +38,7 @@ const StudentRoute = ({ component: Component, ...rest }) => {
 StudentRoute.propTypes = {
   component: PropTypes.any,
   name: PropTypes.string,
-  location: PropTypes.any,
+  location: PropTypes.any
 };
-
 
 export default StudentRoute;

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -9,10 +9,14 @@ const authenticated = () => {
   return Cookies.get('access_token') ? true : false;
 };
 
+const isAdmin = () => {
+  return Cookies.get('user_type') === 'admin' ? true : false;
+};
+
 const login = (email, password) => {
   return API.post('/login', {
     email: email,
-    password: password,
+    password: password
   });
 };
 
@@ -23,8 +27,9 @@ const logout = () => {
 const AuthService = {
   getUser,
   authenticated,
+  isAdmin,
   login,
-  logout,
+  logout
 };
 
 export default AuthService;


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-241

### Definition of Done
- [x] Allow Admin Login

### Related PR

BE PR Link: https://github.com/framgia/sph-classroom-els-be/pull/45

### Commands to Run

N/A

### Notes
#### Main note
- Student users should not be able to log in using the login form for the admin users, [vice versa]
- Student users should not be able to access pages that are for admins only as well [vice versa]

- Sign-in button will disable if you have already submitted and will just enable if there is an error

- Use the admin account created from the seeders to log in as an admin. 
   > if you have already run the seeders command before, you should already have an admin account present in your local DB
   > to determine an Admin account it should have a user_type_id of `1`
   
#### Pages Affected
- http://localhost:3003/admin/login

### Scenarios/ Test Cases
- [ ] it should `redirect to categories list page` when `an admin user successfully logs in` 
- [ ] it should `not grant access to student accounts` when `trying to login using a student account` [vice versa]

### Screenshots
IT SHOULD LOOK LIKE THIS WHEN TRYING TO LOG IN USING A STUDENT ACCOUNT: [VICE VERSA]

![image](https://user-images.githubusercontent.com/91049234/151525459-0ace2b93-77d4-4230-b2a8-caba842ca63b.png)

ADMIN USERS SHOULD NOT BE ABLE TO ACCESS STUDENT PAGES [VICE VERSA]

> Admin trying to access student pages
   ![ADMIN TRYING TO ACCESS STUDENT PAGES](https://user-images.githubusercontent.com/91049234/151527600-693c2316-7a44-40d1-a15e-07296af6dc04.gif)

> Student trying to access admin pages
   ![STUDENT TRYING TO ACCESS ADMIN PAGES](https://user-images.githubusercontent.com/91049234/151527956-1720435b-ae61-4c00-bdd7-81d282e20cde.gif)




