### PR TITLE
E_CLASSROOM-256 [Bugfix] Avatar in the Student List and Friend's Score section is not displaying properly

### DIFF
--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -25,6 +25,7 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
     AnswerApi.getAll(quizTakenId).then(({ data }) => {
       setAnswers(data.data);
     });
+
     FriendsScoreApi.getAll(quizId).then(({ data }) => {
       setFriendsScore(data.data);
     });
@@ -103,8 +104,9 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                                     className={style.friendsAvatar}
                                     alt="avatar"
                                     src={
-                                      friendScore.avatar ||
-                                      'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
+                                      friendScore.avatar
+                                        ? friendScore.avatar_url
+                                        : 'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
                                     }
                                   />
                                 </div>

--- a/src/pages/student/students/StudentList/index.js
+++ b/src/pages/student/students/StudentList/index.js
@@ -119,9 +119,9 @@ const StudentList = () => {
             <img
               alt="avatar"
               src={
-                student.avatar === null
-                  ? 'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
-                  : student.avatar
+                student.avatar
+                  ? student.avatar_url
+                  : 'https://www.pngall.com/wp-content/uploads/5/Profile-Avatar-PNG.png'
               }
               className={style.avatar}
             />

--- a/src/pages/student/students/StudentList/index.module.css
+++ b/src/pages/student/students/StudentList/index.module.css
@@ -100,6 +100,7 @@
 
 .avatar {
   margin-right: 7px;
+  border-radius: 50%;
   width: 38px;
   height: 38px;
 }


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-256

### Definition of Done
- [x] The avatars of the students in the Students List page and Friend's Score section should already display.

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/48

### Commands to Run
N/A
### Notes
#### Main note
- N/A
#### Pages Affected
- STUDENTS LIST PAGE:  http://localhost:3003/students
- QUIZ RESULT PAGE:      http://localhost:3003/categories/1/quizzes/1/questions
#### User Interface
- [ ] when `viewing the Students List page and the Quiz Result it` should `display the avatars of the students`
### Screenshots
STUDENTS LIST PAGE
> ![image](https://user-images.githubusercontent.com/91049234/152760616-c9958f41-5ad4-4911-b3b0-c8c45036ce0a.png)

QUIZ RESULT PAGE [Friend's Score Section]
> ![image](https://user-images.githubusercontent.com/91049234/152760768-8ff28135-4bbc-4ff8-a389-9bed3cfa91ac.png)

