### PR TITLE
E_CLASSROOM-264 [FE] [Improvement] Removed Success Toast for Login and Logout Functionality

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -19,7 +19,6 @@ const NavigationBar = () => {
 
     try {
       await AuthApi.logout();
-      toast('Success', 'Successfully Logged Out.');
       Cookies.remove('access_token');
       window.location = '/login';
     } catch (error) {

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -34,7 +34,6 @@ const AdminLogin = () => {
 
     try {
       const response = await AuthApi.login({ email, password, loginType: 'Admin' });
-      toast('Success', 'Successfully Logged In.');
       Cookies.set('access_token', response.data.token);
       Cookies.set('admin_id', response.data.user.id);
       Cookies.set('user_type', 'admin');
@@ -44,7 +43,10 @@ const AdminLogin = () => {
       setSubmitStatus(false);
       if (error?.response?.data?.error) {
         setError(error?.response?.data?.error);
-        showAlertDialog(true, error?.response?.data?.error?.unauthorized || 'Incorrect Credentials');
+        showAlertDialog(
+          true,
+          error?.response?.data?.error?.unauthorized || 'Incorrect Credentials'
+        );
       } else {
         showAlertDialog(true, 'An error has occurred.');
       }
@@ -54,7 +56,12 @@ const AdminLogin = () => {
   return (
     <div className="d-flex justify-content-center align-items-center">
       {showAlert && (
-        <Alert className={`${style.alert}`} variant="danger" onClose={() => setShowAlert(false)} dismissible>
+        <Alert
+          className={`${style.alert}`}
+          variant="danger"
+          onClose={() => setShowAlert(false)}
+          dismissible
+        >
           {alertMessage}
         </Alert>
       )}
@@ -87,7 +94,9 @@ const AdminLogin = () => {
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{error?.email || error?.unauthorized}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">
+                    {error?.email || error?.unauthorized}
+                  </Form.Control.Feedback>
                 </Form.Group>
 
                 <Form.Group className="mb-1" controlId="password">
@@ -112,7 +121,9 @@ const AdminLogin = () => {
                       />
                     )}
                   />
-                  <Form.Control.Feedback type="invalid">{error?.password}</Form.Control.Feedback>
+                  <Form.Control.Feedback type="invalid">
+                    {error?.password}
+                  </Form.Control.Feedback>
                 </Form.Group>
 
                 <center>

--- a/src/pages/student/main/Login/index.js
+++ b/src/pages/student/main/Login/index.js
@@ -32,7 +32,6 @@ const Login = () => {
 
     try {
       const response = await AuthApi.login({ email, password, loginType: 'Student' });
-      toast('Success', 'Successfully Logged In.');
       Cookies.set('access_token', response.data.token);
       Cookies.set('user_id', response.data.user.id);
       Cookies.set('user_type', 'student');

--- a/src/pages/student/profile/EditProfile/index.js
+++ b/src/pages/student/profile/EditProfile/index.js
@@ -47,8 +47,8 @@ const EditProfile = () => {
 
     try {
       await ProfileEditApi.profileEdit({ name, email, password });
-      toast('Success', 'Successfully Changed Your Account Information.');
       history.push('/profile/view');
+      toast('Success', 'Successfully Changed Your Account Information.');
     } catch (error) {
       toast('Error', error?.response?.data?.error?.error);
       setSubmitStatus(false);


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-264

### Definition of Done
- [x] When logging in and logging out there should be no success toasts anymore.
- [x] Success toasts should only display after redirecting.

### Commands to Run
N/A
### Notes
#### Main note
- N/A
#### Pages Affected
-STUDENT LOGIN PAGE:  http://localhost:3003/login
-STUDENT DASHBOARD PAGE:  http://localhost:3003/ [to test logout]
- ADMIN LOGIN PAGE: http://localhost:3003/admin/login
