### PR TITLE
E_CLASSROOM-250 [UI] Display Quiz Overview

### DIFF
--- a/src/components/NavigationSideBar/index.module.css
+++ b/src/components/NavigationSideBar/index.module.css
@@ -126,7 +126,7 @@
 }
 
 .logoutPosition {
-  margin-top: 14rem;
+  margin-top: 13rem;
   margin-bottom: 1.4rem;
 }
 

--- a/src/pages/admin/quizzes/QuizDetail/components/IdentificationAccordion/index.js
+++ b/src/pages/admin/quizzes/QuizDetail/components/IdentificationAccordion/index.js
@@ -1,0 +1,35 @@
+import React, { Fragment } from 'react';
+import { PropTypes } from 'prop-types';
+import Accordion from 'react-bootstrap/Accordion';
+
+import { BsClockHistory, BsFillCheckCircleFill } from 'react-icons/bs';
+
+import style from '../../components/index.module.scss';
+
+const IdentificationAccordion = ({ questionNumber, question }) => {
+  return (
+    <Fragment>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>
+          <span>
+            {questionNumber}. {question.question}
+          </span>
+          <span className={style.timeLimit}>
+            <BsClockHistory /> {question.time_limit} seconds
+          </span>
+        </Accordion.Header>
+        <Accordion.Body className={style.accordionBody}>
+          <BsFillCheckCircleFill className={style.checkMarkIcon} />
+          {question.correct_answer}
+        </Accordion.Body>
+      </Accordion.Item>
+    </Fragment>
+  );
+};
+
+IdentificationAccordion.propTypes = {
+  question: PropTypes.object,
+  questionNumber: PropTypes.number
+};
+
+export default IdentificationAccordion;

--- a/src/pages/admin/quizzes/QuizDetail/components/MultipleChoiceAccordion/index.js
+++ b/src/pages/admin/quizzes/QuizDetail/components/MultipleChoiceAccordion/index.js
@@ -1,0 +1,43 @@
+import React, { Fragment } from 'react';
+import { PropTypes } from 'prop-types';
+import Accordion from 'react-bootstrap/Accordion';
+
+import { BsClockHistory, BsFillCheckCircleFill, BsXCircleFill } from 'react-icons/bs';
+
+import style from '../../components/index.module.scss';
+
+const MultipleChoiceAccordion = ({ questionNumber, question }) => {
+  return (
+    <Fragment>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>
+          <span>
+            {questionNumber}. {question.question}
+          </span>
+          <span className={style.timeLimit}>
+            <BsClockHistory /> {question.time_limit} seconds
+          </span>
+        </Accordion.Header>
+        {question.choices.map((choice, idx) => {
+          return (
+            <Accordion.Body key={idx} className={style.accordionBody}>
+              {choice.isCorrect ? (
+                <BsFillCheckCircleFill className={style.checkMarkIcon} />
+              ) : (
+                <BsXCircleFill className={style.wrongMarkIcon} />
+              )}
+              {choice.choice}
+            </Accordion.Body>
+          );
+        })}
+      </Accordion.Item>
+    </Fragment>
+  );
+};
+
+MultipleChoiceAccordion.propTypes = {
+  question: PropTypes.object,
+  questionNumber: PropTypes.number
+};
+
+export default MultipleChoiceAccordion;

--- a/src/pages/admin/quizzes/QuizDetail/components/index.module.scss
+++ b/src/pages/admin/quizzes/QuizDetail/components/index.module.scss
@@ -1,26 +1,40 @@
 @use '../../../../../styles/variables' as *;
 
+%flex-and-center {
+  display: flex;
+  align-items: center;
+}
+
+%answers-style {
+  font-size: $font-size-base;
+  font-weight: $font-weight-light;
+  color: $color-dark-blue-1;
+  margin-right: 10px;
+}
+
 .wrongMarkIcon {
   color: $color-incorrect;
-  margin-right: 10px;
+
+  @extend %answers-style;
 }
 
 .checkMarkIcon {
   color: $color-correct;
-  margin-right: 10px;
+
+  @extend %answers-style;
 }
 
 .timeLimit {
-  display: flex;
-  align-items: center;
-  gap: 7px;
+  margin-right: 50px;
   position: absolute;
   right: 0;
-  margin-right: 50px;
+  gap: 7px;
+
+  @extend %flex-and-center;
 }
 
 .accordionBody {
-  display: flex;
-  align-items: center;
   border-bottom: 1px solid $color-light-blue-1;
+
+  @extend %flex-and-center;
 }

--- a/src/pages/admin/quizzes/QuizDetail/components/index.module.scss
+++ b/src/pages/admin/quizzes/QuizDetail/components/index.module.scss
@@ -1,0 +1,26 @@
+@use '../../../../../styles/variables' as *;
+
+.wrongMarkIcon {
+  color: $color-incorrect;
+  margin-right: 10px;
+}
+
+.checkMarkIcon {
+  color: $color-correct;
+  margin-right: 10px;
+}
+
+.timeLimit {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  position: absolute;
+  right: 0;
+  margin-right: 50px;
+}
+
+.accordionBody {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid $color-light-blue-1;
+}

--- a/src/pages/admin/quizzes/QuizDetail/index.js
+++ b/src/pages/admin/quizzes/QuizDetail/index.js
@@ -11,6 +11,7 @@ import IdentificationAccordion from './components/IdentificationAccordion';
 import style from './index.module.scss';
 
 const QuizDetail = () => {
+  const quizTitle = 'Web Development Basics';
   const questions = [
     {
       id: 1,
@@ -19,12 +20,12 @@ const QuizDetail = () => {
       time_limit: 10,
       choices: [
         {
-          choice: 'HyperText Markup Language',
-          isCorrect: true
+          choice: 'How To Make Lumpia',
+          isCorrect: false
         },
         {
-          choice: 'How To Make Lugaw',
-          isCorrect: false
+          choice: 'HyperText Markup Language',
+          isCorrect: true
         },
         {
           choice: 'Hyper Tell Mixed Language',
@@ -52,7 +53,7 @@ const QuizDetail = () => {
           <div className="d-flex mb-5">
             <div className="d-flex gap-4 align-items-center">
               <BsFillArrowLeftSquareFill className={style.backButton} />
-              <h1 className={style.quizTitle}>Web Development</h1>
+              <h1 className={style.quizTitle}>{quizTitle}</h1>
             </div>
             <Button className={style.editButton}>Edit Quiz</Button>
           </div>

--- a/src/pages/admin/quizzes/QuizDetail/index.js
+++ b/src/pages/admin/quizzes/QuizDetail/index.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import Container from 'react-bootstrap/Container';
+import Accordion from 'react-bootstrap/Accordion';
+import Button from 'react-bootstrap/Button';
+
+import { BsFillArrowLeftSquareFill } from 'react-icons/bs';
+
+import MultipleChoiceAccordion from './components/MultipleChoiceAccordion';
+import IdentificationAccordion from './components/IdentificationAccordion';
+
+import style from './index.module.scss';
+
+const QuizDetail = () => {
+  const questions = [
+    {
+      id: 1,
+      question_type: 'Multiple Choice',
+      question: 'What is HTML?',
+      time_limit: 10,
+      choices: [
+        {
+          choice: 'HyperText Markup Language',
+          isCorrect: true
+        },
+        {
+          choice: 'How To Make Lugaw',
+          isCorrect: false
+        },
+        {
+          choice: 'Hyper Tell Mixed Language',
+          isCorrect: false
+        },
+        {
+          choice: 'Hyper Tale Mark Language',
+          isCorrect: false
+        }
+      ]
+    },
+    {
+      id: 1,
+      question_type: 'Identification',
+      question: 'Tim Berners-Lee invented ______.',
+      time_limit: 20,
+      correct_answer: 'World Wide Web'
+    }
+  ];
+
+  return (
+    <div className="d-inline-flex">
+      <Container className={style.quizContainer}>
+        <div className="flex-column">
+          <div className="d-flex mb-5">
+            <div className="d-flex gap-4 align-items-center">
+              <BsFillArrowLeftSquareFill className={style.backButton} />
+              <h1 className={style.quizTitle}>Web Development</h1>
+            </div>
+            <Button className={style.editButton}>Edit Quiz</Button>
+          </div>
+          <h4 className={style.questionText}>Questions ({questions.length})</h4>
+          {questions &&
+            questions.map((question, idx) => {
+              return (
+                <Accordion key={idx} className="w-100" alwaysOpen>
+                  {question.question_type === 'Multiple Choice' ? (
+                    <MultipleChoiceAccordion
+                      questionNumber={idx + 1}
+                      question={question}
+                    />
+                  ) : (
+                    <IdentificationAccordion
+                      questionNumber={idx + 1}
+                      question={question}
+                    />
+                  )}
+                </Accordion>
+              );
+            })}
+        </div>
+      </Container>
+    </div>
+  );
+};
+
+export default QuizDetail;

--- a/src/pages/admin/quizzes/QuizDetail/index.js
+++ b/src/pages/admin/quizzes/QuizDetail/index.js
@@ -37,7 +37,7 @@ const QuizDetail = () => {
       ]
     },
     {
-      id: 1,
+      id: 2,
       question_type: 'Identification',
       question: 'Tim Berners-Lee invented ______.',
       time_limit: 20,

--- a/src/pages/admin/quizzes/QuizDetail/index.module.scss
+++ b/src/pages/admin/quizzes/QuizDetail/index.module.scss
@@ -1,0 +1,50 @@
+@use '../../../../styles/variables' as *;
+
+.quizContainer {
+  width: 926px;
+  height: 800px;
+
+  position: absolute;
+  left: 650px;
+  top: 90px;
+
+  background: $color-white;
+  border: 1px solid $color-white-2;
+  color: $color-dark-blue-1;
+  border-radius: 2px;
+  padding: 50px;
+}
+
+.backButton {
+  cursor: pointer;
+  font-size: 27px;
+
+  &:hover {
+    color: #000;
+  }
+}
+
+.quizTitle {
+  font-size: $font-size-page-title;
+  font-weight: $font-weight-semibold;
+}
+
+.editButton {
+  width: 120px;
+  margin-left: auto;
+  color: $color-dark-blue-1;
+  border-color: $color-light-blue-2;
+  background-color: $color-light-blue-2;
+
+  &:hover {
+    color: $color-white;
+    border-color: $color-dark-blue-3;
+    background-color: $color-dark-blue-3;
+  }
+}
+
+.questionText {
+  font-size: $font-size-lg;
+  font-weight: $font-weight-regular;
+  margin-bottom: 20px;
+}

--- a/src/pages/admin/quizzes/QuizDetail/index.module.scss
+++ b/src/pages/admin/quizzes/QuizDetail/index.module.scss
@@ -3,16 +3,39 @@
 .quizContainer {
   width: 926px;
   height: 800px;
+  padding: 50px;
 
   position: absolute;
   left: 650px;
   top: 90px;
 
   background: $color-white;
-  border: 1px solid $color-white-2;
-  color: $color-dark-blue-1;
   border-radius: 2px;
-  padding: 50px;
+  border: 1px solid $color-light-blue-1;
+  color: $color-dark-blue-1;
+
+  overflow: scroll;
+  overflow-x: hidden;
+
+  /* width */
+  &::-webkit-scrollbar {
+    width: 7px;
+  }
+
+  /* Track */
+  &::-webkit-scrollbar-track {
+    background: $color-white;
+  }
+
+  /* Handle */
+  &::-webkit-scrollbar-thumb {
+    background: $color-light-blue-1;
+  }
+
+  /* Handle on hover */
+  &::-webkit-scrollbar-thumb:hover {
+    background: $color-light-blue-2;
+  }
 }
 
 .backButton {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -76,14 +76,34 @@ const Routes = () => {
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>
-      <AuthRoute path="/registration" exact component={Registration}></AuthRoute>
-      <AuthRoute path="/reset-password" exact component={forgotPassword}></AuthRoute>
+      <AuthRoute
+        path="/registration"
+        exact
+        component={Registration}
+      ></AuthRoute>
+      <AuthRoute
+        path="/reset-password"
+        exact
+        component={forgotPassword}
+      ></AuthRoute>
       <AuthRoute path="/new-password" exact component={NewPassword}></AuthRoute>
 
-      <StudentRoute path="/profile" exact component={ProfileDetail}></StudentRoute>
+      <StudentRoute
+        path="/profile"
+        exact
+        component={ProfileDetail}
+      ></StudentRoute>
       <StudentRoute path="/" exact component={Dashboard}></StudentRoute>
-      <StudentRoute path="/students" exact component={StudentList}></StudentRoute>
-      <StudentRoute path="/learnings" exact component={LearningList}></StudentRoute>
+      <StudentRoute
+        path="/students"
+        exact
+        component={StudentList}
+      ></StudentRoute>
+      <StudentRoute
+        path="/learnings"
+        exact
+        component={LearningList}
+      ></StudentRoute>
       <StudentRoute
         path="/learningsdetail"
         exact
@@ -97,7 +117,11 @@ const Routes = () => {
 >>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
         component={LearningDetail}
       ></StudentRoute>
-      <StudentRoute path="/categories" exact component={CategoryList}></StudentRoute>
+      <StudentRoute
+        path="/categories"
+        exact
+        component={CategoryList}
+      ></StudentRoute>
       <StudentRoute
         path="/categories/:id/sub"
         exact
@@ -133,8 +157,16 @@ const Routes = () => {
         exact
         component={ChangePassword}
       ></StudentRoute>
-      <StudentRoute path="/profile/view" exact component={ProfileView}></StudentRoute>
-      <StudentRoute path="/profile/edit" exact component={ProfileEdit}></StudentRoute>
+      <StudentRoute
+        path="/profile/view"
+        exact
+        component={ProfileView}
+      ></StudentRoute>
+      <StudentRoute
+        path="/profile/edit"
+        exact
+        component={ProfileEdit}
+      ></StudentRoute>
       <StudentRoute
         path="/students/:id"
         exact

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,7 +10,11 @@ import AuthRoute from './middleware/AuthRoute';
 import AdminLogin from '../pages/admin/main/Login';
 import AdminCategoryList from '../pages/admin/categories/CategoryList';
 import AddEditCategory from '../pages/admin/categories/AddEditCategory';
+<<<<<<< HEAD
 import AdminQuizList from '../pages/admin/quizzes/QuizList';
+=======
+import AdminQuizDetail from '../pages/admin/quizzes/QuizDetail';
+>>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -59,51 +63,41 @@ const Routes = () => {
       ></AdminRoute>
 
       <AdminRoute
+<<<<<<< HEAD
         path="/admin/quizzes"
         exact
         component={AdminQuizList}
+=======
+        path="/admin/quizzes/:quizId"
+        exact
+        component={AdminQuizDetail}
+>>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
       ></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>
-      <AuthRoute
-        path="/registration"
-        exact
-        component={Registration}
-      ></AuthRoute>
-      <AuthRoute
-        path="/reset-password"
-        exact
-        component={forgotPassword}
-      ></AuthRoute>
+      <AuthRoute path="/registration" exact component={Registration}></AuthRoute>
+      <AuthRoute path="/reset-password" exact component={forgotPassword}></AuthRoute>
       <AuthRoute path="/new-password" exact component={NewPassword}></AuthRoute>
 
-      <StudentRoute
-        path="/profile"
-        exact
-        component={ProfileDetail}
-      ></StudentRoute>
+      <StudentRoute path="/profile" exact component={ProfileDetail}></StudentRoute>
       <StudentRoute path="/" exact component={Dashboard}></StudentRoute>
+      <StudentRoute path="/students" exact component={StudentList}></StudentRoute>
+      <StudentRoute path="/learnings" exact component={LearningList}></StudentRoute>
       <StudentRoute
-        path="/students"
+        path="/learningsdetail"
         exact
-        component={StudentList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/learnings"
-        exact
+<<<<<<< HEAD
         component={LearningList}
       ></StudentRoute>
       <StudentRoute
         path="/learningsdetail"
         exact
+=======
+>>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
         component={LearningDetail}
       ></StudentRoute>
-      <StudentRoute
-        path="/categories"
-        exact
-        component={CategoryList}
-      ></StudentRoute>
+      <StudentRoute path="/categories" exact component={CategoryList}></StudentRoute>
       <StudentRoute
         path="/categories/:id/sub"
         exact
@@ -139,16 +133,8 @@ const Routes = () => {
         exact
         component={ChangePassword}
       ></StudentRoute>
-      <StudentRoute
-        path="/profile/view"
-        exact
-        component={ProfileView}
-      ></StudentRoute>
-      <StudentRoute
-        path="/profile/edit"
-        exact
-        component={ProfileEdit}
-      ></StudentRoute>
+      <StudentRoute path="/profile/view" exact component={ProfileView}></StudentRoute>
+      <StudentRoute path="/profile/edit" exact component={ProfileEdit}></StudentRoute>
       <StudentRoute
         path="/students/:id"
         exact

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,11 +10,8 @@ import AuthRoute from './middleware/AuthRoute';
 import AdminLogin from '../pages/admin/main/Login';
 import AdminCategoryList from '../pages/admin/categories/CategoryList';
 import AddEditCategory from '../pages/admin/categories/AddEditCategory';
-<<<<<<< HEAD
 import AdminQuizList from '../pages/admin/quizzes/QuizList';
-=======
 import AdminQuizDetail from '../pages/admin/quizzes/QuizDetail';
->>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -63,15 +60,15 @@ const Routes = () => {
       ></AdminRoute>
 
       <AdminRoute
-<<<<<<< HEAD
         path="/admin/quizzes"
         exact
         component={AdminQuizList}
-=======
+      ></AdminRoute>
+
+      <AdminRoute
         path="/admin/quizzes/:quizId"
         exact
         component={AdminQuizDetail}
->>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
       ></AdminRoute>
 
       {/* STUDENT ROUTES */}
@@ -107,14 +104,6 @@ const Routes = () => {
       <StudentRoute
         path="/learningsdetail"
         exact
-<<<<<<< HEAD
-        component={LearningList}
-      ></StudentRoute>
-      <StudentRoute
-        path="/learningsdetail"
-        exact
-=======
->>>>>>> bb93bd2 (E_CLASSROOM-250 [UI] Display Quiz Overview)
         component={LearningDetail}
       ></StudentRoute>
       <StudentRoute

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,7 +1,9 @@
 $color-white: #ffffff;
 $color-white-2: #f5f5f5;
+$color-white-3: #fafafa;
 $color-black: #000000;
-$color-red: #ff0000;
+$color-incorrect: rgb(112, 0, 0);
+$color-correct: rgb(0, 102, 0);
 
 $color-light-blue-1: #e0eaec;
 $color-light-blue-2: #c0d5d8;


### PR DESCRIPTION
### Issue Link

### Definition of Done
- [x] UI follows the figma design [except for the Accordion]
- [x] User can expand and collapse the accordion to view the answers
- [x] All quiz questions should be shown in one page only
- [x] For: Accordion behavior, user can open all questions.

### Commands to Run
N/A
### Notes
#### Main note
- Please disregard the accordion styling, I was not able to fully follow the Figma Design of the accordion as I encountered a problem with overriding the default styling of bootstrap, and as discussed by me and Sir Karlo, he will just create another task for that.


#### Pages Affected
- Login as Admin before accessing the link below.
  
   http://localhost:3003/admin/quizzes/1

### Scenarios/ Test Cases
- [x] it should `display quiz information and its corresponding question and answers` when `viewing quiz overview page`
- [x] it should `collapse or show the choices/answers of the question` when `clicking a specific question`
- [x] it should `stay open` even when `opening another accordion`

### Screenshots
> ![image](https://user-images.githubusercontent.com/91049234/153370828-6e4b314a-6ca8-43bb-b4c1-76827353b113.png)


> ![image](https://user-images.githubusercontent.com/91049234/153369679-8adddbb3-1125-487e-89e8-039f542b6d03.png)
