### PR TITLE
E_CLASSROOM-271 [Bugfix] Clicking on Categories Redirects to Blank Page

### DIFF
--- a/src/components/NavigationSideBar/index.js
+++ b/src/components/NavigationSideBar/index.js
@@ -59,7 +59,7 @@ const NavigationSideBar = () => {
           </Nav.Link>
         </LinkContainer>
         <LinkContainer
-          to="/admin"
+          to="/admin/categories"
           className={`${style.displayFlexRow} ${style.navItemInfo}`}
         >
           <Nav.Link href="#" className={style.navItem}>


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-271

### Definition of Done
- [x] User must be redirected to the categories page when clicking the categories navlink.

### Commands to Run
N/A
### Notes
#### Main note
- 
#### Pages Affected

- ADMIN SIDEBAR: http://localhost:3003/admin/quizzes

### Scenarios/ Test Cases
- [ ] it should `redirect to the categories page` when `clicking the categories nav link` 

### Screenshots
> ![REDIRECT TO CATEGORIES PAGE](https://user-images.githubusercontent.com/91049234/153829349-36ab9699-d2eb-46f4-a398-d0a8b80dc1cc.gif)
