### PR TITLE
E_CLASSROOM-270 [Bugfix] Apply Red Color for Failed Scores and Apply Validation Error Messages for Duplicate Emails

### DIFF
--- a/src/pages/student/profile/EditProfile/index.js
+++ b/src/pages/student/profile/EditProfile/index.js
@@ -44,18 +44,31 @@ const EditProfile = () => {
     toast('Processing', 'Changing your account information...');
     setSubmitStatus(true);
     setShowAlert(false);
+    setErrors({});
 
     try {
       await ProfileEditApi.profileEdit({ name, email, password });
       history.push('/profile/view');
       toast('Success', 'Successfully Changed Your Account Information.');
     } catch (error) {
-      toast('Error', error?.response?.data?.error?.error);
+      toast(
+        'Error',
+        error?.response?.data?.error?.password ||
+          error?.response?.data?.errors?.email
+      );
+
       setSubmitStatus(false);
-      if (error?.response?.data?.errors) {
-        setErrors(error?.response?.data?.errors);
-      } else if (error?.response?.data?.error) {
-        showAlertDialog(true, 'The password you have entered is incorrect.');
+
+      if (error?.response?.data?.error || error?.response?.data?.errors) {
+        setErrors(
+          error?.response?.data?.error || error?.response?.data?.errors
+        );
+
+        showAlertDialog(
+          true,
+          error?.response?.data?.error?.password ||
+            error?.response?.data?.errors?.email
+        );
       } else {
         showAlertDialog(true, 'An error has occurred.');
       }
@@ -92,8 +105,14 @@ const EditProfile = () => {
             <span className={style.loadingWord}>Loading</span>
           </div>
         ) : (
-          <Form onSubmit={handleSubmit(handleOnSubmit)} style={{ marginTop: '20px' }}>
-            <Form.Group className={style.marginForForm} controlId="formBasicName">
+          <Form
+            onSubmit={handleSubmit(handleOnSubmit)}
+            style={{ marginTop: '20px' }}
+          >
+            <Form.Group
+              className={style.marginForForm}
+              controlId="formBasicName"
+            >
               <Form.Label className={style.FormGroupStyle}>Name</Form.Label>
               {profileName ? (
                 <Controller
@@ -122,7 +141,10 @@ const EditProfile = () => {
               </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className={style.marginForForm} controlId="formBasicEmail">
+            <Form.Group
+              className={style.marginForForm}
+              controlId="formBasicEmail"
+            >
               <Form.Label className={style.FormGroupStyle}>Email</Form.Label>
               {profileName ? (
                 <Controller
@@ -152,7 +174,10 @@ const EditProfile = () => {
               </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className={style.marginForForm} controlId="formBasicPassword">
+            <Form.Group
+              className={style.marginForForm}
+              controlId="formBasicPassword"
+            >
               <Form.Label className={style.FormGroupStyle}>Password</Form.Label>
               {profileName ? (
                 <Controller

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
@@ -21,6 +21,7 @@ const QuizAnswerResult = ({
   const { questions, title } = useContext(QuestionsContext);
   const [question, setQuestion] = useState(questions[page - 1]);
   const [answer, setAnswer] = useState(answers[page - 1]);
+  const passingScore = total / 2;
 
   const handlePrevButtonClick = () => {
     if (page <= 1) return;
@@ -60,7 +61,13 @@ const QuizAnswerResult = ({
             <div className={style.scorebg1}>Score</div>
             <Card.Text className={style.score1}>
               <span className={style.timeleftspace1}>
-                <b className={style.timer1}>{score}</b>
+                <b
+                  className={
+                    score < passingScore ? `${style.fail}` : `${style.pass}`
+                  }
+                >
+                  {score}
+                </b>
               </span>
               <b>/ {total}</b>
             </Card.Text>

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.css
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.css
@@ -250,3 +250,11 @@ input [type='radio']:disabled {
   color: green;
   margin-bottom: 25px;
 }
+
+.pass {
+  color: green;
+}
+
+.fail {
+  color: red;
+}


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-270

### Definition of Done
- [x] The font color for failed scores should already be red on the view quiz results page.
- [x] There should already be validation errors for duplicate emails.
### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/51

### Commands to Run
N/A
### Notes
#### Main note
- Try editing your email to an email that is already being used by another user.
#### Pages Affected
- QUIZ RESULTS PAGE: http://localhost:3003/categories/7/quizzes/7/questions
- PROFILE EDIT PAGE: http://localhost:3003/profile/view

### Screenshots
- Red font color for failed scores
> ![image](https://user-images.githubusercontent.com/91049234/153851935-7d2f60e7-a8e5-4e7b-b991-3b8c26a6330a.png)

- Validation Error Messages for the Profile Edit Page
> ![PROFILE EDIT VALIDATION ERROR MESSAGES](https://user-images.githubusercontent.com/91049234/153852011-28b74cb2-d039-4caa-810f-d609806dd388.gif)
