### PR TITLE
E_CLASSROOM-274 [Bugfix] Next button in the Results page has a differ…

### DIFF
--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
@@ -15,7 +15,7 @@ const QuizAnswerResult = ({
   score,
   total,
   categoryId,
-  viewResultsPage
+  viewResultsPage,
 }) => {
   const [page, setPage] = useState(1);
   const { questions, title } = useContext(QuestionsContext);
@@ -75,10 +75,10 @@ const QuizAnswerResult = ({
           <Card.Body className={style.wholeBodyCard1}>
             {question &&
             question.question_type.question_type === 'Multiple Choice' ? (
-                <MultipleChoiceType question={question} answer={answer} />
-              ) : (
-                <FillInTheBlankType question={question} answer={answer} />
-              )}
+              <MultipleChoiceType question={question} answer={answer} />
+            ) : (
+              <FillInTheBlankType question={question} answer={answer} />
+            )}
             <hr />
             <div className={style.bottomBodyCard1}>
               <p className={style.numItems1}>
@@ -103,7 +103,7 @@ const QuizAnswerResult = ({
                   </a>
                 ) : (
                   <Button
-                    className={style.nextbutton}
+                    className={style.nextButton}
                     onClick={handleNextButtonClick}
                   >
                     Next
@@ -124,7 +124,7 @@ QuizAnswerResult.propTypes = {
   answers: PropTypes.array,
   score: PropTypes.number,
   total: PropTypes.number,
-  categoryId: PropTypes.number
+  categoryId: PropTypes.number,
 };
 
 export default QuizAnswerResult;

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
@@ -75,10 +75,10 @@ const QuizAnswerResult = ({
           <Card.Body className={style.wholeBodyCard1}>
             {question &&
             question.question_type.question_type === 'Multiple Choice' ? (
-              <MultipleChoiceType question={question} answer={answer} />
-            ) : (
-              <FillInTheBlankType question={question} answer={answer} />
-            )}
+                <MultipleChoiceType question={question} answer={answer} />
+              ) : (
+                <FillInTheBlankType question={question} answer={answer} />
+              )}
             <hr />
             <div className={style.bottomBodyCard1}>
               <p className={style.numItems1}>

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.css
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.css
@@ -223,13 +223,19 @@ input [type='radio']:disabled {
   color: #48535b;
 }
 
-.nextbutton {
+.nextButton {
   width: 80px;
   height: 32px;
   font-size: 14px;
   background-color: #c0d5d8;
   border-color: #c0d5d8;
   color: #48535b;
+}
+
+.nextButton:hover {
+  background-color: #9abec1;
+  border-color: #9abec1;
+  color: white;
 }
 
 .button:hover {


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-274

### Definition of Done
- [ ] Change hover color of `Next Button` in Quiz Result's answers

### Commands to Run
- N/A

### Notes
#### Main note
- Take a quiz then `View Results`
#### Pages Affected
- http://localhost:3003/categories/7/quizzes/7/questions

### Scenarios/ Test Cases
- [ ] Change hover color of `Next Button` in Quiz Result's answers
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![next](https://user-images.githubusercontent.com/89382692/154674671-93674113-1e7b-491d-b81e-89b5e8440ecb.gif)
