### PR TITLE
E_CLASSROOM-275 [Bugfix] Category name cannot be edited and description misleading error message

### DIFF
--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -46,8 +46,8 @@ const AddEditCategory = () => {
         toast('Error', error?.response?.data?.errors?.description);
       }
     } else {
-        toast('Error', 'There`s an Error in the Data. Please try again...');
-        setSubmitStatus(false);
+      toast('Error', 'There`s an Error in the Data. Please try again...');
+      setSubmitStatus(false);
     } 
   };
 

--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -18,7 +18,7 @@ const AddEditCategory = () => {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
-  const { control, handleSubmit, reset } = useForm();
+  const { control, handleSubmit } = useForm();
   const [errors, setErrors] = useState({});
   const [submitStatus, setSubmitStatus] = useState(false);
   const { category_id } = useParams();
@@ -37,9 +37,18 @@ const AddEditCategory = () => {
     }
   }, []);
 
-  const detectTypo = () => {
-    toast('Error', 'Category name is Already Taken. Please try again...');
-    setSubmitStatus(false);
+  const detectTypo = (error) => {
+    if (loc.pathname === '/admin/add-category') {
+      setSubmitStatus(false);
+      if (error?.response?.data?.errors?.name) {
+        toast('Error', error?.response?.data?.errors?.name);
+      } else {
+        toast('Error', error?.response?.data?.errors?.description);
+      }
+    } else {
+        toast('Error', 'There`s an Error in the Data. Please try again...');
+        setSubmitStatus(false);
+    } 
   };
 
   const handleOnSubmit = async ({ name, description }) => {
@@ -55,10 +64,6 @@ const AddEditCategory = () => {
         })
         .catch((error) => {
           detectTypo(error);
-          reset({
-            name: '',
-            description: ''
-          });
         });
     } else if (loc.pathname === `/admin/edit-category/${category_id}`) {
       toast('Processing', 'Updating Category...');
@@ -107,7 +112,6 @@ const AddEditCategory = () => {
                     type="title"
                     placeholder="Category Name"
                     isInvalid={!!errors?.name}
-                    required
                     maxLength={50}
                   />
                 )}
@@ -147,6 +151,7 @@ const AddEditCategory = () => {
                     as="textarea"
                     placeholder="Category Description"
                     isInvalid={!!errors?.description}
+                    maxLength={255}
                   />
                 )}
               />


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-275
### Definition of Done
- [x] Put max length in description field to 255 characters
- [x] Should be able to change category name and description

### Commands to Run

### Related PR:
- https://github.com/framgia/sph-classroom-els-be/pull/55
### Notes
#### Main note
- http://localhost:3003/admin/edit-category/:category_id
#### Pages Affected
- N/A

### Scenarios/ Test Cases
- [ ] Able to change Category title
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![error4](https://user-images.githubusercontent.com/89514595/155277972-82183b3f-1f6a-4538-8fb7-e69401710b98.gif)
![error5](https://user-images.githubusercontent.com/89514595/155277987-a4d1ce92-6604-47f5-86bc-86614737deb2.gif)

