### PR TITLE
E_CLASSROOM-288 (Dependent #296) [FE/BE] Quizzes Sort by Column

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
-import { Table } from 'react-bootstrap';
+import { Spinner, Table, Button } from 'react-bootstrap';
 import { BsArrowUp, BsArrowDown } from 'react-icons/bs';
 
 import style from './index.module.scss';
@@ -24,6 +24,7 @@ import { useEffect } from 'react';
     > titleHeaderStyle : it will take the style.
     > sortOptions      : to get the initial value.
     > setSortOptions   : To get the value of the sortBy and sortDescsription, to determine how to sort the list.
+    > data             : This is the data you want to load inside the table, this is only to determine if the data is still being loaded or not.
   */
 
 const DataTable = ({
@@ -31,14 +32,15 @@ const DataTable = ({
   renderTableData,
   titleHeaderStyle,
   sortOptions,
-  setSortOptions
+  setSortOptions,
+  data
 }) => {
   const [sortBy, setSortBy] = useState(sortOptions.sortBy);
   const [sortDirection, setSortDirection] = useState(sortOptions.sortDirection);
 
   useEffect(() => {
     setSortOptions({ sortBy, sortDirection });
-  }, [sortDirection]);
+  }, [sortBy, sortDirection]);
 
   const renderArrowIcons = (name) => {
     if (sortBy === name && sortBy !== 'Edit') {
@@ -87,7 +89,14 @@ const DataTable = ({
           <td className={titleHeaderStyle}>Delete</td>
         </tr>
       </thead>
-      <tbody>{renderTableData()}</tbody>
+      {data ? (
+        <tbody>{renderTableData()}</tbody>
+      ) : (
+        <Button className={style.spinner} disabled>
+          <Spinner animation="border" />
+          <span>Loading</span>
+        </Button>
+      )}
     </Table>
   );
 };
@@ -97,7 +106,8 @@ DataTable.propTypes = {
   renderTableData: PropTypes.func,
   titleHeaderStyle: PropTypes.any,
   sortOptions: PropTypes.object,
-  setSortOptions: PropTypes.func
+  setSortOptions: PropTypes.func,
+  data: PropTypes.array
 };
 
 export default DataTable;

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -50,6 +50,18 @@ const DataTable = ({
     }
   };
 
+  const onSortClick = (headerName) => {
+    if (sortBy !== headerName) {
+      setSortBy(headerName);
+      setSortDirection('asc');
+    } else if (sortDirection === 'asc') {
+      setSortDirection('desc');
+    } else {
+      setSortBy('');
+      setSortDirection('');
+    }
+  };
+
   return (
     <Table className={style.formatTable}>
       <thead>
@@ -59,13 +71,7 @@ const DataTable = ({
               <td
                 className={titleHeaderStyle}
                 onClick={() => {
-                  setSortBy(header.title);
-
-                  if (sortDirection === 'desc') {
-                    setSortDirection('asc');
-                  } else {
-                    setSortDirection('desc');
-                  }
+                  onSortClick(header.title);
                 }}
                 key={idx}
               >

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import { Table } from 'react-bootstrap';
+import { BsArrowUp, BsArrowDown } from 'react-icons/bs';
 
 import style from './index.module.scss';
+import { useEffect } from 'react';
 
 /*
     To use this component, pass the following props:
@@ -20,14 +22,61 @@ import style from './index.module.scss';
     
     > renderTableData : its prop-type is a function, therefore you should only pass a function that would render the list of data needed for the table.
     > titleHeaderStyle : it will take the style.
+    > sortOptions      : to get the initial value.
+    > setSortOptions   : To get the value of the sortBy and sortDescsription, to determine how to sort the list.
   */
-const DataTable = ({ tableHeaderNames, renderTableData, titleHeaderStyle }) => {
+
+const DataTable = ({
+  tableHeaderNames,
+  renderTableData,
+  titleHeaderStyle,
+  sortOptions,
+  setSortOptions
+}) => {
+  const [sortBy, setSortBy] = useState(sortOptions.sortBy);
+  const [sortDirection, setSortDirection] = useState(sortOptions.sortDirection);
+
+  useEffect(() => {
+    setSortOptions({ sortBy, sortDirection });
+  }, [sortDirection]);
+
+  const renderArrowIcons = (name) => {
+    if (sortBy === name && sortBy !== 'Edit') {
+      return sortDirection === 'asc' ? (
+        <BsArrowUp className={style.arrowIcons} />
+      ) : (
+        <BsArrowDown className={style.arrowIcons} />
+      );
+    }
+  };
+
   return (
     <Table className={style.formatTable}>
       <thead>
         <tr>
           {tableHeaderNames.map((header, idx) => {
-            return <td className={titleHeaderStyle} key={idx}>{header.title}</td>;
+            return (
+              <td
+                className={titleHeaderStyle}
+                onClick={() => {
+                  setSortBy(header.title);
+
+                  if (sortDirection === 'desc') {
+                    setSortDirection('asc');
+                  } else {
+                    setSortDirection('desc');
+                  }
+                }}
+                key={idx}
+              >
+                <div
+                  className={header.title !== 'Edit' ? style.headerName : ''}
+                >
+                  <span>{header.title}</span>
+                  <div>{renderArrowIcons(header.title)}</div>
+                </div>
+              </td>
+            );
           })}
           <td className={titleHeaderStyle}>Delete</td>
         </tr>
@@ -40,7 +89,9 @@ const DataTable = ({ tableHeaderNames, renderTableData, titleHeaderStyle }) => {
 DataTable.propTypes = {
   tableHeaderNames: PropTypes.array,
   renderTableData: PropTypes.func,
-  titleHeaderStyle: PropTypes.any
+  titleHeaderStyle: PropTypes.any,
+  sortOptions: PropTypes.object,
+  setSortOptions: PropTypes.func
 };
 
 export default DataTable;

--- a/src/components/DataTable/index.module.scss
+++ b/src/components/DataTable/index.module.scss
@@ -1,4 +1,18 @@
+@use '../../styles/variables' as *;
+
 .formatTable {
-    width: 100%;
-    margin-top: 63px;
-  }
+  width: 100%;
+  margin-top: 63px;
+}
+
+.headerName {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: $font-size-lg;
+  cursor: pointer;
+}
+
+.arrowIcons {
+  height: 27px;
+}

--- a/src/components/DataTable/index.module.scss
+++ b/src/components/DataTable/index.module.scss
@@ -1,18 +1,38 @@
 @use '../../styles/variables' as *;
 
+%flex-align-center {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
 .formatTable {
   width: 100%;
   margin-top: 63px;
 }
 
 .headerName {
-  display: flex;
-  align-items: center;
-  gap: 5px;
   font-size: $font-size-lg;
   cursor: pointer;
+
+  @extend %flex-align-center;
 }
 
 .arrowIcons {
   height: 27px;
+}
+
+.spinner {
+  position: absolute;
+  height: 25px;
+  left: 580px;
+  top: 380px;
+
+  @extend %flex-align-center;
+
+  &:disabled {
+    background-color: $color-white;
+    color: $color-black;
+    border: none;
+  }
 }

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -25,8 +25,8 @@ const QuizList = () => {
   const [adminquiz, setAdminquiz] = useState(null);
   const queryParams = new URLSearchParams(window.location.search);
   const pageNum = queryParams.get('page');
-  const sortBy = queryParams.get('sortBy');
-  const sortDirection = queryParams.get('sortDirection');
+  const sortBy = queryParams.get('sortBy') || '';
+  const sortDirection = queryParams.get('sortDirection') || '';
   const [modalShow, setModalShow] = useState(false);
   const [errors, setErrors] = useState({});
   const [submitStatus, setSubmitStatus] = useState(false);

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -5,12 +5,9 @@ import { useHistory } from 'react-router-dom';
 import Form from 'react-bootstrap/Form';
 import FormControl from 'react-bootstrap/FormControl';
 import Button from '@restart/ui/esm/Button';
-import Dropdown from 'react-bootstrap/Dropdown';
-import { VscFilter } from 'react-icons/vsc';
 import { BiSearch } from 'react-icons/bi';
 import { FaRegEdit } from 'react-icons/fa';
 import { RiDeleteBin2Fill } from 'react-icons/ri';
-import { BsSortAlphaDown } from 'react-icons/bs';
 import { Link } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Container from 'react-bootstrap/Container';
@@ -22,7 +19,7 @@ import AddQuizModal from './components/AddQuizModal';
 import DataTable from '../../../../components/DataTable';
 
 const QuizList = () => {
-  const [adminquiz, setAdminquiz] = useState(null);
+  const [adminQuiz, setAdminQuiz] = useState(null);
   const queryParams = new URLSearchParams(window.location.search);
   const pageNum = queryParams.get('page');
   const sortBy = queryParams.get('sortBy') || '';
@@ -70,12 +67,14 @@ const QuizList = () => {
   };
 
   const load = () => {
+    setAdminQuiz(null);
+
     QuizApi.adminQuiz({
-      page,
-      sortBy,
-      sortDirection
+      page: page,
+      sortBy: sortOptions.sortBy,
+      sortDirection: sortOptions.sortDirection
     }).then(({ data }) => {
-      setAdminquiz(data.data);
+      setAdminQuiz(data.data);
       setPerPage(data.per_page);
       setTotalItems(data.total);
       setLastPage(data.last_page);
@@ -106,7 +105,7 @@ const QuizList = () => {
   ];
 
   const renderTableData = () => {
-    return adminquiz?.map((quiz, idx) => {
+    return adminQuiz?.map((quiz, idx) => {
       return (
         <tr key={idx}>
           <td id={style.classColumn}>{quiz.id}</td>
@@ -147,48 +146,6 @@ const QuizList = () => {
                       </Button>
                     </Form>
                   </div>
-
-                  <Dropdown style={{ margin: '0px 0px 0px 683px' }}>
-                    <Dropdown.Toggle
-                      className={style.dropdownStyle}
-                      variant="link"
-                      bsPrefix="none"
-                    >
-                      <span className={style.dropdownText}>Filter</span>
-                      <VscFilter size="20px" />
-                    </Dropdown.Toggle>
-                  </Dropdown>
-                  <Dropdown>
-                    <Dropdown.Toggle
-                      className={style.dropdownStyle}
-                      variant="link"
-                      bsPrefix="none"
-                    >
-                      <span className={style.dropdownText}>Sort</span>
-                      <BsSortAlphaDown size="20px" />
-                    </Dropdown.Toggle>
-                  </Dropdown>
-
-                  <Dropdown style={{ margin: '0px 0px 0px 683px' }}>
-                    <Dropdown.Toggle
-                      className={style.dropdownStyle}
-                      variant="link"
-                      bsPrefix="none"
-                    >
-                      <span className={style.dropdownText}>Filter</span>
-                      <VscFilter size="20px" />
-                    </Dropdown.Toggle>
-                  </Dropdown>
-                  <Dropdown>
-                    <Dropdown.Toggle
-                      className={style.dropdownStyle}
-                      variant="link"
-                      bsPrefix="none"
-                    >
-                      <span className={style.dropdownText}>Sort</span>
-                      <BsSortAlphaDown size="20px" />
-                    </Dropdown.Toggle>
-                  </Dropdown>
                 </div>
                 <table style={{ width: '100%' }}>
                   <tbody>
@@ -213,6 +170,7 @@ const QuizList = () => {
                     titleHeaderStyle={style.classCol}
                     sortOptions={sortOptions}
                     setSortOptions={setSortOptions}
+                    data={adminQuiz}
                   />
                 </div>
               </Card.Body>

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -91,10 +91,6 @@ const QuizList = () => {
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
-
-    history.push(
-      `?page=${page}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
-    );
   };
 
   const tableHeaderNames = [

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -25,6 +25,8 @@ const QuizList = () => {
   const [adminquiz, setAdminquiz] = useState(null);
   const queryParams = new URLSearchParams(window.location.search);
   const pageNum = queryParams.get('page');
+  const sortBy = queryParams.get('sortBy');
+  const sortDirection = queryParams.get('sortDirection');
   const [modalShow, setModalShow] = useState(false);
   const [errors, setErrors] = useState({});
   const [submitStatus, setSubmitStatus] = useState(false);
@@ -32,6 +34,11 @@ const QuizList = () => {
 
   const history = useHistory();
   const toast = useToast();
+
+  const [sortOptions, setSortOptions] = useState({
+    sortBy,
+    sortDirection
+  });
 
   const [page, setPage] = useState(pageNum ? parseInt(pageNum) : 1);
   const [perPage, setPerPage] = useState(0);
@@ -64,7 +71,9 @@ const QuizList = () => {
 
   const load = () => {
     QuizApi.adminQuiz({
-      page: page,
+      page,
+      sortBy,
+      sortDirection
     }).then(({ data }) => {
       setAdminquiz(data.data);
       setPerPage(data.per_page);
@@ -74,22 +83,26 @@ const QuizList = () => {
   };
 
   useEffect(() => {
-    history.push(`?page=${page}`);
+    history.push(
+      `?page=${page}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
+    );
 
     load();
-  }, [page]);
+  }, [page, sortOptions]);
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
 
-    history.push(`?page=${page}`);
+    history.push(
+      `?page=${page}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
+    );
   };
 
   const tableHeaderNames = [
     { title: 'ID' },
     { title: 'Category' },
     { title: 'Name' },
-    { title: 'Edit' },
+    { title: 'Edit' }
   ];
 
   const renderTableData = () => {
@@ -198,6 +211,8 @@ const QuizList = () => {
                     tableHeaderNames={tableHeaderNames}
                     renderTableData={renderTableData}
                     titleHeaderStyle={style.classCol}
+                    sortOptions={sortOptions}
+                    setSortOptions={setSortOptions}
                   />
                 </div>
               </Card.Body>

--- a/src/pages/admin/quizzes/QuizList/index.module.scss
+++ b/src/pages/admin/quizzes/QuizList/index.module.scss
@@ -74,28 +74,6 @@
   height: 20px;
 }
 
-.dropdownStyle {
-  display: flex;
-  justify-content: end;
-  background-color: $color-white;
-  border: 1px $color-white solid;
-  color: $color-dark-blue-1;
-  text-decoration: none;
-  width: 100px;
-  height: 32px;
-  margin: 3px 0px 3px 12px;
-  align-items: center;
-}
-
-.dropdownText {
-  margin-right: 22px;
-  font-size: $font-size-md;
-}
-
-.dropdownStyle:hover {
-  color: $color-dark-blue-1;
-}
-
 .button {
   @extend %style-button;
   margin-right: auto;
@@ -221,7 +199,7 @@
   color: $color-dark-blue-1;
 }
 
-.classCol{
+.classCol {
   @extend %style-table-head;
 
   &:nth-child(1) {
@@ -237,12 +215,12 @@
   }
 
   &:nth-child(4) {
-      width: 151px;
-      text-align: center;
+    width: 151px;
+    text-align: center;
   }
 
   &:nth-child(5) {
-      width: 151px;
-      text-align: center;
+    width: 151px;
+    text-align: center;
   }
 }


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-288

### Definition of Done 
* [x] User should be able to sort by id, name, and category
* [x] Refreshing the page should keep the sort option
* [x] Arrow icon should be visible when the column is sorted
* [x] First click should sort by ascending
* [x] Second click on same column, sort by descending
* [x] Third click on same column, sort by default

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/61

### Notes
#### Main Note
- I removed the Sort and Filter Dropdown Buttons
#### Pages Affected
- Quiz List Page: http://localhost:3003/admin/quizzes

### Screenshots
> ![QUIZZES SORT BY COLUMN](https://user-images.githubusercontent.com/91049234/156501080-2dd0ab84-2a91-44e8-bb52-7b18fb46334a.gif)