### PR TITLE
E_CLASSROOM-299 [FE/BE] [Admin] Change Password Page

### DIFF
--- a/src/api/Admin/index.js
+++ b/src/api/Admin/index.js
@@ -27,7 +27,7 @@ const AdminApi = {
 
     return API.request(options);
   },
-  
+
   getAllUsers: (id) => {
     const options = {
       method: 'GET',
@@ -35,6 +35,20 @@ const AdminApi = {
     };
     return API.request(options);
   },
+
+  updatePassword: ({ password, new_password, password_confirmation }) => {
+    const options = {
+      method: 'PATCH',
+      url: '/admin/password-edit',
+      data: {
+        password: password,
+        new_password: new_password,
+        password_confirmation: password_confirmation
+      }
+    };
+
+    return API.request(options);
+  }
 };
 
 export default AdminApi;

--- a/src/pages/admin/profile/EditPassword/index.js
+++ b/src/pages/admin/profile/EditPassword/index.js
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import { useHistory, Link } from 'react-router-dom';
+import { useForm, Controller } from 'react-hook-form';
+import { useToast } from '../../../../hooks/useToast';
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button';
+
+import style from './index.module.scss';
+
+import AdminApi from '../../../../api/Admin';
+
+const EditPassword = () => {
+  const { control, handleSubmit, reset } = useForm();
+  const [errors, setErrors] = useState({});
+  const [submitStatus, setSubmitStatus] = useState(false);
+
+  const history = useHistory();
+  const toast = useToast();
+
+  const handleOnSubmit = async ({
+    password,
+    new_password,
+    password_confirmation
+  }) => {
+    setSubmitStatus(true);
+    toast('Processing', 'Updating your current password...');
+    setErrors({});
+
+    await AdminApi.updatePassword({
+      password,
+      new_password,
+      password_confirmation
+    })
+      .then(({ data }) => {
+        history.push('/admin/profile');
+        toast('Success', data.message);
+        setSubmitStatus(false);
+        reset({
+          password: '',
+          new_password: '',
+          password_confirmation: ''
+        });
+      })
+      .catch((error) => {
+        setSubmitStatus(false);
+        toast(
+          'Error',
+          error?.response?.data?.message ||
+            error?.response?.data?.error?.password
+        );
+        setErrors(
+          error?.response?.data?.errors || error?.response?.data?.error
+        );
+      });
+  };
+
+  return (
+    <div className="d-inline-flex">
+      <Form onSubmit={handleSubmit(handleOnSubmit)} className={style.form}>
+        <h3 className={style.formTitle}>Change Password</h3>
+        <div>
+          <Form.Group className="mb-3" controlId="formBasicPassword">
+            <Form.Label className={style.inputLabel}>
+              Current Password
+            </Form.Label>
+            <Controller
+              control={control}
+              name="password"
+              render={({ field: { onChange, value, ref } }) => (
+                <Form.Control
+                  className={style.inputField}
+                  type="password"
+                  placeholder="enter current password"
+                  onChange={onChange}
+                  value={value}
+                  ref={ref}
+                  isInvalid={!!errors?.password}
+                  maxLength={20}
+                  autocomplete="on"
+                  required
+                />
+              )}
+            />
+            <Form.Control.Feedback
+              className={style.validationMessage}
+              type="invalid"
+            >
+              {errors?.password}
+            </Form.Control.Feedback>
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="formBasicNewPassword">
+            <Form.Label className={style.inputLabel}>New Password</Form.Label>
+            <Controller
+              control={control}
+              name="new_password"
+              render={({ field: { onChange, value, ref } }) => (
+                <Form.Control
+                  className={style.inputField}
+                  type="password"
+                  placeholder="min. of 6 characters"
+                  onChange={onChange}
+                  value={value}
+                  ref={ref}
+                  isInvalid={!!errors?.new_password}
+                  maxLength={20}
+                  autocomplete="on"
+                  required
+                />
+              )}
+            />
+            <Form.Control.Feedback
+              className={style.validationMessage}
+              type="invalid"
+            >
+              {errors?.new_password}
+            </Form.Control.Feedback>
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="formBasicConfirmPassword">
+            <Form.Label className={style.inputLabel}>
+              Confirm Password
+            </Form.Label>
+            <Controller
+              control={control}
+              name="password_confirmation"
+              render={({ field: { onChange, value, ref } }) => (
+                <Form.Control
+                  className={style.inputField}
+                  type="password"
+                  placeholder="match new password"
+                  onChange={onChange}
+                  value={value}
+                  ref={ref}
+                  isInvalid={!!errors?.password_confirmation}
+                  maxLength={20}
+                  autocomplete="on"
+                  required
+                />
+              )}
+            />
+            <Form.Control.Feedback
+              className={style.validationMessage}
+              type="invalid"
+            >
+              {errors?.password_confirmation}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </div>
+        <Button
+          className={style.changeButton}
+          type="submit"
+          disabled={submitStatus}
+        >
+          Change
+        </Button>
+        <Link to="/admin/profile" className={style.cancelButton}>
+          Cancel
+        </Link>
+      </Form>
+    </div>
+  );
+};
+
+export default EditPassword;

--- a/src/pages/admin/profile/EditPassword/index.module.scss
+++ b/src/pages/admin/profile/EditPassword/index.module.scss
@@ -1,0 +1,68 @@
+@use '../../../../styles/variables' as *;
+
+%button-style {
+  font-size: $font-size-md;
+  color: $color-dark-blue-1;
+}
+
+.formTitle {
+  font-weight: $font-weight-regular;
+  font-size: $font-size-page-title;
+}
+
+.form {
+  position: absolute;
+  left: 880px;
+  top: 230px;
+
+  width: 450px;
+  height: auto;
+  padding: 40px 30px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 25px;
+
+  background-color: $color-light-blue-1;
+  color: $color-dark-blue-1;
+}
+
+.inputLabel {
+  font-weight: $font-weight-regular;
+  font-size: $font-size-base;
+}
+
+.inputField,
+.validationMessage {
+  width: 335px;
+}
+
+.changeButton {
+  background-color: $color-light-blue-2;
+  border: none;
+  width: 85px;
+  height: 35px;
+
+  @extend %button-style;
+
+  &:hover,
+  &:focus {
+    background-color: $color-dark-blue-3;
+  }
+
+  &:disabled {
+    background-color: $color-dark-blue-3;
+    opacity: 0.5;
+  }
+}
+
+.cancelButton {
+  @extend %button-style;
+
+  &:hover,
+  &:focus {
+    color: $color-black;
+  }
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -17,6 +17,7 @@ import AdminCreateAdmin from '../pages/admin/Admin/CreateAdmin';
 import AdminSetPassword from '../pages/admin/Admin/SetAdminPassword';
 import AdminProfile from '../pages/admin/profile/Profile';
 import AdminEditProfile from '../pages/admin/profile/EditProfile';
+import AdminEditPassword from '../pages/admin/profile/EditPassword';
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -104,6 +105,12 @@ const Routes = () => {
         path="/admin/profile/edit"
         exact
         component={AdminEditProfile}
+      ></AdminRoute>
+
+      <AdminRoute
+        path="/admin/profile/edit-password"
+        exact
+        component={AdminEditPassword}
       ></AdminRoute>
 
       {/* STUDENT ROUTES */}


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-299

### Definition of Done
* [x] User can change password successfully
* [x] User should not be able to change their password if "Old Password" is incorrect
* [x] Validation should be present
* [x] Layout should be the same as the Figma design
* [x] After successful password update, redirect to profile view page

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/63

### Notes
#### Main note
- After successfully updating the password, it will redirect to a blank page since the Admin Profile Page is not yet implemented.
#### Pages Affected
- http://localhost:3003/admin/profile/edit-password

### Screenshots
> ![EDIT PASSWORD](https://user-images.githubusercontent.com/91049234/156530891-e208a14c-fa63-408c-b539-72f9540cb571.gif)
