### PR TITLE
E_CLASSROOM-276 [FE/BE] Accounts List Page

### DIFF
--- a/src/api/Admin/index.js
+++ b/src/api/Admin/index.js
@@ -48,6 +48,17 @@ const AdminApi = {
     };
 
     return API.request(options);
+  },
+
+  getAdminAccounts: ({ ...params }) => {
+    const options = {
+      method: 'GET',
+      url: '/admin/admins',
+      params: {
+        ...params
+      }
+    };
+    return API.request(options);
   }
 };
 

--- a/src/api/Admin/index.js
+++ b/src/api/Admin/index.js
@@ -53,7 +53,7 @@ const AdminApi = {
   getAdminAccounts: ({ ...params }) => {
     const options = {
       method: 'GET',
-      url: '/admin/admins',
+      url: '/admin/users',
       params: {
         ...params
       }

--- a/src/components/NavigationSideBar/index.js
+++ b/src/components/NavigationSideBar/index.js
@@ -86,7 +86,7 @@ const NavigationSideBar = () => {
           </Nav.Link>
         </LinkContainer>
         <LinkContainer
-          to="/admin/admins"
+          to="/admin/users"
           className={`${style.displayFlexRow} ${style.navItemInfo}`}
         >
           <Nav.Link href="#" className={style.navItem}>

--- a/src/components/NavigationSideBar/index.js
+++ b/src/components/NavigationSideBar/index.js
@@ -86,7 +86,7 @@ const NavigationSideBar = () => {
           </Nav.Link>
         </LinkContainer>
         <LinkContainer
-          to="/admin"
+          to="/admin/admins"
           className={`${style.displayFlexRow} ${style.navItemInfo}`}
         >
           <Nav.Link href="#" className={style.navItem}>

--- a/src/components/NavigationSideBar/index.module.css
+++ b/src/components/NavigationSideBar/index.module.css
@@ -10,6 +10,7 @@
 }
 
 .navbar {
+  position: fixed;
   background-color: #002037;
   display: inline-flex;
   justify-content: flex-start;

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -79,55 +79,53 @@ const AdminList = () => {
   };
 
   return (
-    <div className={style.adminListContainer}>
-      <div className={style.mainContent}>
-        <div>
-          <h1 className={style.pageTitle}>Admin Accounts</h1>
-        </div>
-        <Card className={style.card}>
-          <Card.Header className={style.cardHeader}>
-            <Form className={style.searchSection}>
-              <div className={style.searchInput}>
-                <Form.Control
-                  className={style.searchBar}
-                  type="text"
-                  placeholder="Search name or email"
-                />
-                <BiSearch size={17} className={style.searchIcon} />
-              </div>
-              <Button className={style.searchButton} type="submit">
-                Search
-              </Button>
-            </Form>
-            <Dropdown>
-              <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
-                Filter
-                <VscFilter size={17} />
-              </Dropdown.Toggle>
-            </Dropdown>
-          </Card.Header>
-          <Card.Body className={style.cardBody}>
-            <Button className={style.addAdminButton}>Add an Admin</Button>
-            <DataTable
-              tableHeaderNames={tableHeaderNames}
-              renderTableData={renderTableData}
-              titleHeaderStyle={style.tableHeader}
-              sortOptions={sortOptions}
-              setSortOptions={setSortOptions}
-              data={adminAccounts}
-            />
-          </Card.Body>
-        </Card>
-        <section>
-          <Pagination
-            page={page}
-            perPage={perPage}
-            totalItems={totalItems}
-            pageCount={lastPage}
-            onPageChange={onPageChange}
-          />
-        </section>
+    <div className={style.mainContent}>
+      <div>
+        <h1 className={style.pageTitle}>Admin Accounts</h1>
       </div>
+      <Card className={style.card}>
+        <Card.Header className={style.cardHeader}>
+          <Form className={style.searchSection}>
+            <div className={style.searchInput}>
+              <Form.Control
+                className={style.searchBar}
+                type="text"
+                placeholder="Search name or email"
+              />
+              <BiSearch size={17} className={style.searchIcon} />
+            </div>
+            <Button className={style.searchButton} type="submit">
+              Search
+            </Button>
+          </Form>
+          <Dropdown>
+            <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
+              Filter
+              <VscFilter size={17} />
+            </Dropdown.Toggle>
+          </Dropdown>
+        </Card.Header>
+        <Card.Body className={style.cardBody}>
+          <Button className={style.addAdminButton}>Add an Admin</Button>
+          <DataTable
+            tableHeaderNames={tableHeaderNames}
+            renderTableData={renderTableData}
+            titleHeaderStyle={style.tableHeader}
+            sortOptions={sortOptions}
+            setSortOptions={setSortOptions}
+            data={adminAccounts}
+          />
+        </Card.Body>
+      </Card>
+      <section>
+        <Pagination
+          page={page}
+          perPage={perPage}
+          totalItems={totalItems}
+          pageCount={lastPage}
+          onPageChange={onPageChange}
+        />
+      </section>
     </div>
   );
 };

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -1,0 +1,135 @@
+import React, { useState, useEffect } from 'react';
+import { useHistory, Link } from 'react-router-dom';
+import { useToast } from '../../../../hooks/useToast';
+import Card from 'react-bootstrap/Card';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import Dropdown from 'react-bootstrap/Dropdown';
+import { VscFilter } from 'react-icons/vsc';
+import { BiSearch } from 'react-icons/bi';
+import { FaRegEdit } from 'react-icons/fa';
+import { RiDeleteBin2Fill } from 'react-icons/ri';
+import Pagination from '../../../../components/Pagination';
+import DataTable from '../../../../components/DataTable';
+import AdminApi from '../../../../api/Admin';
+import style from './index.module.scss';
+
+const AdminList = () => {
+  const queryParams = new URLSearchParams(window.location.search);
+  const pageNum = queryParams.get('page');
+  const sortBy = queryParams.get('sortBy') || '';
+  const sortDirection = queryParams.get('sortDirection') || '';
+  const history = useHistory();
+  const toast = useToast();
+
+  const [adminAccounts, setAdminAccounts] = useState();
+  const [page, setPage] = useState(pageNum ? parseInt(pageNum) : 1);
+  const [perPage, setPerPage] = useState(0);
+  const [totalItems, setTotalItems] = useState(0);
+  const [lastPage, setLastPage] = useState(0);
+  const [sortOptions, setSortOptions] = useState({
+    sortBy,
+    sortDirection
+  });
+
+  const tableHeaderNames = [
+    { title: 'ID' },
+    { title: 'Name' },
+    { title: 'Email' },
+    { title: 'Edit' }
+  ];
+
+  useEffect(() => {
+    AdminApi.getAdminAccounts({ page })
+      .then(({ data }) => {
+        setAdminAccounts(data.data);
+        setPerPage(data.per_page);
+        setTotalItems(data.total);
+        setLastPage(data.last_page);
+      })
+      .catch(() =>
+        toast('Error', 'There was an error getting the list of admin accounts.')
+      );
+  }, [page]);
+
+  const onPageChange = (selected) => {
+    setPage(selected + 1);
+
+    history.push(`?page=${selected + 1}`);
+  };
+
+  const renderTableData = () => {
+    return adminAccounts?.map((admin, idx) => {
+      return (
+        <tr key={idx} className={style.tableDataRow}>
+          <td className={style.tableData}>{admin.id}</td>
+          <td className={style.tableData}>{admin.name}</td>
+          <td className={style.tableData}>{admin.email}</td>
+          <td className={`${style.tableData} ${style.buttonColumn}`}>
+            <Link to={`/admin/admins/${admin.id}`}>
+              <FaRegEdit size="20px" color="black" />
+            </Link>
+          </td>
+          <td className={`${style.tableData} ${style.buttonColumn}`}>
+            <RiDeleteBin2Fill size="25px" color="#db7771" />
+          </td>
+        </tr>
+      );
+    });
+  };
+
+  return (
+    <div className={style.adminListContainer}>
+      <div className={style.mainContent}>
+        <div>
+          <h1 className={style.pageTitle}>Admin Accounts</h1>
+        </div>
+        <Card className={style.card}>
+          <Card.Header className={style.cardHeader}>
+            <Form className={style.searchSection}>
+              <div className={style.searchInput}>
+                <Form.Control
+                  className={style.searchBar}
+                  type="text"
+                  placeholder="Search name or email"
+                />
+                <BiSearch size={17} className={style.searchIcon} />
+              </div>
+              <Button className={style.searchButton} type="submit">
+                Search
+              </Button>
+            </Form>
+            <Dropdown>
+              <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
+                Filter
+                <VscFilter size={17} />
+              </Dropdown.Toggle>
+            </Dropdown>
+          </Card.Header>
+          <Card.Body className={style.cardBody}>
+            <Button className={style.addAdminButton}>Add an Admin</Button>
+            <DataTable
+              tableHeaderNames={tableHeaderNames}
+              renderTableData={renderTableData}
+              titleHeaderStyle={style.tableHeader}
+              sortOptions={sortOptions}
+              setSortOptions={setSortOptions}
+              data={adminAccounts}
+            />
+          </Card.Body>
+        </Card>
+        <section>
+          <Pagination
+            page={page}
+            perPage={perPage}
+            totalItems={totalItems}
+            pageCount={lastPage}
+            onPageChange={onPageChange}
+          />
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default AdminList;

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory, Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
@@ -7,7 +7,6 @@ import Form from 'react-bootstrap/Form';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { VscFilter } from 'react-icons/vsc';
 import { BiSearch } from 'react-icons/bi';
-import { FaRegEdit } from 'react-icons/fa';
 import { RiDeleteBin2Fill } from 'react-icons/ri';
 import Pagination from '../../../../components/Pagination';
 import DataTable from '../../../../components/DataTable';
@@ -35,8 +34,7 @@ const AdminList = () => {
   const tableHeaderNames = [
     { title: 'ID' },
     { title: 'Name' },
-    { title: 'Email' },
-    { title: 'Edit' }
+    { title: 'Email' }
   ];
 
   useEffect(() => {
@@ -65,11 +63,6 @@ const AdminList = () => {
           <td className={style.tableData}>{admin.id}</td>
           <td className={style.tableData}>{admin.name}</td>
           <td className={style.tableData}>{admin.email}</td>
-          <td className={`${style.tableData} ${style.buttonColumn}`}>
-            <Link to={`/admin/admins/${admin.id}`}>
-              <FaRegEdit size="20px" color="black" />
-            </Link>
-          </td>
           <td className={`${style.tableData} ${style.buttonColumn}`}>
             <RiDeleteBin2Fill size="25px" color="#db7771" />
           </td>

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -38,6 +38,10 @@ const AdminList = () => {
   ];
 
   useEffect(() => {
+    load();
+  }, [page]);
+
+  const load = () => {
     AdminApi.getAdminAccounts({ page })
       .then(({ data }) => {
         setAdminAccounts(data.data);
@@ -48,7 +52,7 @@ const AdminList = () => {
       .catch(() =>
         toast('Error', 'There was an error getting the list of admin accounts.')
       );
-  }, [page]);
+  };
 
   const onPageChange = (selected) => {
     setPage(selected + 1);

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -1,0 +1,127 @@
+@use '../../../../styles/variables' as *;
+
+@mixin button-style($background-color, $width, $height) {
+  background-color: $background-color;
+  color: $color-dark-blue-1;
+  font-size: $font-size-md;
+  border: none;
+  height: $height;
+  width: $width;
+}
+
+@mixin flex($justify-value, $align-value, $direction, $gap-value) {
+  display: flex;
+  align-items: $align-value;
+  justify-content: $justify-value;
+  flex-direction: $direction;
+  gap: $gap-value;
+}
+
+.mainContent {
+  position: absolute;
+  height: 100%;
+  width: calc(100% - 300px);
+  left: 300px;
+  padding: 60px 165px 0px;
+
+  @include flex(none, none, column, 30px);
+}
+
+.pageTitle {
+  font-weight: $font-weight-medium;
+  font-size: $font-size-page-title;
+}
+
+.card {
+  width: 100%;
+  height: 745px;
+}
+
+.cardHeader {
+  height: auto;
+  background-color: $color-light-blue-1;
+  padding: 12px 20px;
+  box-shadow: $drop-shadow;
+
+  @include flex(space-between, none, row, 0px);
+}
+
+.searchSection {
+  @include flex(none, center, row, 10px);
+}
+
+.searchInput {
+  position: relative;
+}
+
+.searchBar {
+  width: 335px;
+  padding-right: 34px;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 92%;
+  top: 28%;
+}
+
+.searchButton {
+  @include button-style($color-light-blue-2, 93px, 38px);
+
+  &:hover {
+    background-color: $color-dark-blue-3;
+  }
+}
+
+.dropdownButton {
+  @include flex(center, center, row, 10px);
+  @include button-style($color-white, 93px, 38px);
+
+  &:hover {
+    background-color: $color-white;
+    color: $color-dark-blue-1;
+  }
+}
+
+.cardBody {
+  padding: 20px;
+  overflow: auto;
+  overflow-x: hidden;
+}
+
+.addAdminButton {
+  float: right;
+  margin: 10px 0px 30px;
+  @include button-style($color-light-blue-2, 172px, 38px);
+
+  &:hover {
+    background-color: $color-dark-blue-3;
+  }
+}
+
+.tableHeader {
+  font-size: $font-size-lg;
+  font-weight: $font-weight-bold;
+
+  &:first-child,
+  &:last-child,
+  &:nth-last-child(2) {
+    width: 110px;
+    text-align: center;
+  }
+}
+
+.tableDataRow {
+  height: 75px;
+  vertical-align: middle;
+  font-size: $font-size-base;
+  color: $color-dark-blue-1;
+}
+
+.tableData {
+  border-bottom-width: 0px !important;
+}
+
+.buttonColumn {
+  text-align: center;
+}

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -104,8 +104,7 @@
   font-weight: $font-weight-bold;
 
   &:first-child,
-  &:last-child,
-  &:nth-last-child(2) {
+  &:last-child {
     width: 110px;
     text-align: center;
   }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ import AdminSetPassword from '../pages/admin/Admin/SetAdminPassword';
 import AdminProfile from '../pages/admin/profile/Profile';
 import AdminEditProfile from '../pages/admin/profile/EditProfile';
 import AdminEditPassword from '../pages/admin/profile/EditPassword';
+import AdminList from '../pages/admin/Admin/AdminList';
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -112,6 +113,8 @@ const Routes = () => {
         exact
         component={AdminEditPassword}
       ></AdminRoute>
+
+      <AdminRoute path="/admin/admins" exact component={AdminList}></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -114,7 +114,7 @@ const Routes = () => {
         component={AdminEditPassword}
       ></AdminRoute>
 
-      <AdminRoute path="/admin/admins" exact component={AdminList}></AdminRoute>
+      <AdminRoute path="/admin/users" exact component={AdminList}></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-276

### Definition of Done
- [x] Dynamic display of all admin accounts
- [x] Pagination is working
- [x] Seeder command is working
- [x] 'Add an Admin' button should display but no functionality yet

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/66

### Notes
#### Main note
- Run the seeders command mentioned in the BE PR to add more admin users to test pagination functionality, before checking FE PR.
#### Pages Affected

- ADMIN ACCOUNTS PAGE: http://localhost:3003/admin/users

### Screenshots
> ![ADMIN ACCOUNTS](https://user-images.githubusercontent.com/91049234/156983429-9b123ad6-bb83-4272-8e2a-4b5e5e2f23df.gif)
