### PR TITLE
E_CLASSROOM-303 [FE/BE] Category Hierarchy Page

### DIFF
--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -103,7 +103,10 @@
   font-size: $font-size-lg;
   font-weight: $font-weight-bold;
 
-  &:first-child,
+  &:first-child {
+    width: 110px;
+  }
+
   &:last-child {
     width: 110px;
     text-align: center;

--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -115,117 +115,122 @@ const AddEditCategory = () => {
   };
 
   return (
-    <Card className={style.card}>
-      <Card.Header className={style.header}>
-        <div>
-          <a href="/admin/categories">
-            <BsFillArrowLeftSquareFill className={style.backArrow} />
-          </a>
+    <div className={style.cardContainer}>
+      <Card className={style.card}>
+        <Card.Header className={style.header}>
+          <div>
+            <a href="/admin/categories">
+              <BsFillArrowLeftSquareFill className={style.backArrow} />
+            </a>
+          </div>
+          <div className={style.headerText}>
+            <span>
+              {loc.pathname === '/admin/add-category'
+                ? 'Add a Category'
+                : 'Edit Category'}
+            </span>
+          </div>
+        </Card.Header>
+        <Card.Body className={style.cardBody}>
+          {(category && locationPathDisplay) ||
+          loc.pathname === '/admin/add-category' ? (
+              <Form onSubmit={handleSubmit(handleOnSubmit)}>
+                <Form.Group
+                  className={style.inputFieldContainer}
+                  controlId="name"
+                >
+                  <Form.Label className={style.inputLabel}>Title</Form.Label>
+                  <Controller
+                    control={control}
+                    name="name"
+                    defaultValue={category?.name}
+                    render={({ field: { onChange, value, ref } }) => (
+                      <Form.Control
+                        className={style.inputField}
+                        onChange={onChange}
+                        value={value}
+                        ref={ref}
+                        type="title"
+                        placeholder="Category Name"
+                        isInvalid={!!errors?.name}
+                        maxLength={50}
+                      />
+                    )}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {errors?.name}
+                  </Form.Control.Feedback>
+                </Form.Group>
+                <Form.Group
+                  className={style.inputFieldContainer}
+                  controlId="lacation"
+                >
+                  <Form.Label className={style.inputLabel}>Location</Form.Label>
+                  <Form.Control
+                    className={`${style.inputField} ${style.spaceForIconArea}`}
+                    readOnly="readonly"
+                    type="text"
+                    value={locationPathDisplay}
+                    onClick={handleShow}
+                  />
+                  <CgMenuCake className={style.menuIcon} onClick={handleShow} />
+                </Form.Group>
+                <Form.Group controlId="description">
+                  <Form.Label className={`${style.inputLabel} mt-3`}>
+                  Description
+                  </Form.Label>
+                  <Controller
+                    control={control}
+                    name="description"
+                    defaultValue={category?.description}
+                    render={({ field: { onChange, value, ref } }) => (
+                      <Form.Control
+                        className={style.inputFieldDescription}
+                        onChange={onChange}
+                        value={value}
+                        ref={ref}
+                        as="textarea"
+                        placeholder="Category Description"
+                        isInvalid={!!errors?.description}
+                        maxLength={255}
+                      />
+                    )}
+                  />
+                  <Form.Control.Feedback type="invalid">
+                    {errors?.description}
+                  </Form.Control.Feedback>
+                </Form.Group>
+                <Button
+                  className={style.button}
+                  type="submit"
+                  disabled={submitStatus}
+                >
+                  {loc.pathname === '/admin/add-category'
+                    ? 'Add Category'
+                    : 'Save Category'}
+                </Button>
+              </Form>
+            ) : (
+              <div className={style.loading}>
+                <Spinner animation="border" role="status"></Spinner>
+                <span className={style.loadingWord}>Loading</span>
+              </div>
+            )}
+        </Card.Body>
+        <div className={style.modalContainer}>
+          <ChangeLocation
+            show={show}
+            handleClose={handleClose}
+            location={location}
+            setLocation={setLocation}
+            setLocationPathDisplay={setLocationPathDisplay}
+            type={TYPE}
+            isSaved={isSaved}
+            setIsSaved={setIsSaved}
+          />
         </div>
-        <div className={style.headerText}>
-          <span>
-            {loc.pathname === '/admin/add-category'
-              ? 'Add a Category'
-              : 'Edit Category'}
-          </span>
-        </div>
-      </Card.Header>
-      <Card.Body className={style.cardBody}>
-        {(category && locationPathDisplay) ||
-        loc.pathname === '/admin/add-category' ? (
-            <Form onSubmit={handleSubmit(handleOnSubmit)}>
-              <Form.Group className={style.inputFieldContainer} controlId="name">
-                <Form.Label className={style.inputLabel}>Title</Form.Label>
-                <Controller
-                  control={control}
-                  name="name"
-                  defaultValue={category?.name}
-                  render={({ field: { onChange, value, ref } }) => (
-                    <Form.Control
-                      className={style.inputField}
-                      onChange={onChange}
-                      value={value}
-                      ref={ref}
-                      type="title"
-                      placeholder="Category Name"
-                      isInvalid={!!errors?.name}
-                      maxLength={50}
-                    />
-                  )}
-                />
-                <Form.Control.Feedback type="invalid">
-                  {errors?.name}
-                </Form.Control.Feedback>
-              </Form.Group>
-              <Form.Group
-                className={style.inputFieldContainer}
-                controlId="lacation"
-              >
-                <Form.Label className={style.inputLabel}>Location</Form.Label>
-                <Form.Control
-                  className={`${style.inputField} ${style.spaceForIconArea}`}
-                  readOnly="readonly"
-                  type="text"
-                  value={locationPathDisplay}
-                  onClick={handleShow}
-                />
-                <CgMenuCake className={style.menuIcon} onClick={handleShow} />
-              </Form.Group>
-              <Form.Group controlId="description">
-                <Form.Label className={`${style.inputLabel} mt-3`}>
-                Description
-                </Form.Label>
-                <Controller
-                  control={control}
-                  name="description"
-                  defaultValue={category?.description}
-                  render={({ field: { onChange, value, ref } }) => (
-                    <Form.Control
-                      className={style.inputFieldDescription}
-                      onChange={onChange}
-                      value={value}
-                      ref={ref}
-                      as="textarea"
-                      placeholder="Category Description"
-                      isInvalid={!!errors?.description}
-                      maxLength={255}
-                    />
-                  )}
-                />
-                <Form.Control.Feedback type="invalid">
-                  {errors?.description}
-                </Form.Control.Feedback>
-              </Form.Group>
-              <Button
-                className={style.button}
-                type="submit"
-                disabled={submitStatus}
-              >
-                {loc.pathname === '/admin/add-category'
-                  ? 'Add Category'
-                  : 'Save Category'}
-              </Button>
-            </Form>
-          ) : (
-            <div className={style.loading}>
-              <Spinner animation="border" role="status"></Spinner>
-              <span className={style.loadingWord}>Loading</span>
-            </div>
-          )}
-      </Card.Body>
-      <div className={style.modalContainer}>
-        <ChangeLocation
-          show={show}
-          handleClose={handleClose}
-          location={location}
-          setLocation={setLocation}
-          setLocationPathDisplay={setLocationPathDisplay}
-          type={TYPE}
-          isSaved={isSaved}
-          setIsSaved={setIsSaved}
-        />
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 };
 

--- a/src/pages/admin/categories/AddEditCategory/index.module.scss
+++ b/src/pages/admin/categories/AddEditCategory/index.module.scss
@@ -6,13 +6,20 @@
   font-size: $font-size-base;
 }
 
+.cardContainer {
+  position: absolute;
+  height: 100%;
+  width: calc(100% - 300px);
+  left: 300px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .card {
   width: 1063px;
-  display: inline-flex;
-  margin-left: 8rem;
   height: auto;
-  position: fixed;
-  margin-top: 150px;
 }
 
 .header {

--- a/src/pages/admin/categories/CategoryHierarchy/index.js
+++ b/src/pages/admin/categories/CategoryHierarchy/index.js
@@ -17,8 +17,8 @@ const CategoryHierarchy = () => {
   useEffect(() => {
     setCategories(null);
     chosenCategoryPathID
-      ? toast('Processing', 'Getting Subcategories...')
-      : toast('Processing', 'Getting Root Categories...');
+      ? toast('Processing', 'Getting the subcategories...')
+      : toast('Processing', 'Getting the root categories...');
 
     CategoryApi.getCategories({ category_id: chosenCategoryPathID })
       .then(({ data }) => {

--- a/src/pages/admin/categories/CategoryHierarchy/index.js
+++ b/src/pages/admin/categories/CategoryHierarchy/index.js
@@ -20,6 +20,10 @@ const CategoryHierarchy = () => {
       ? toast('Processing', 'Getting the subcategories...')
       : toast('Processing', 'Getting the root categories...');
 
+    load();
+  }, [chosenCategoryPathID]);
+
+  const load = () => {
     CategoryApi.getCategories({ category_id: chosenCategoryPathID })
       .then(({ data }) => {
         setCategories(data.data);
@@ -27,7 +31,7 @@ const CategoryHierarchy = () => {
       .catch(() =>
         toast('Error', 'There was an error getting the list of categories.')
       );
-  }, [chosenCategoryPathID]);
+  };
 
   const onCategoryClick = (category, index) => {
     if (category.subcategories_count > 0) {
@@ -42,7 +46,6 @@ const CategoryHierarchy = () => {
   };
 
   const onBreadcrumbClick = (category_id, index) => {
-    console.log(breadcrumbs);
     setBreadCrumbs(breadcrumbs.slice(0, index + 1));
     setChosenCategoryPathID(category_id);
   };

--- a/src/pages/admin/categories/CategoryHierarchy/index.js
+++ b/src/pages/admin/categories/CategoryHierarchy/index.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
+import { GoKebabVertical } from 'react-icons/go';
+import { RiArrowRightSLine } from 'react-icons/ri';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Spinner from 'react-bootstrap/Spinner';
 import CategoryApi from '../../../../api/Category';
-import { GoKebabVertical } from 'react-icons/go';
-import { RiArrowRightSLine } from 'react-icons/ri';
 import style from './index.module.scss';
 
 const CategoryHierarchy = () => {
@@ -15,9 +15,10 @@ const CategoryHierarchy = () => {
   const [breadcrumbs, setBreadCrumbs] = useState([]);
 
   useEffect(() => {
-    console.log(breadcrumbs);
     setCategories(null);
-    chosenCategoryPathID ? toast('Processing', 'Getting Subcategories...') : '';
+    chosenCategoryPathID
+      ? toast('Processing', 'Getting Subcategories...')
+      : toast('Processing', 'Getting Root Categories...');
 
     CategoryApi.getCategories({ category_id: chosenCategoryPathID })
       .then(({ data }) => {

--- a/src/pages/admin/categories/CategoryHierarchy/index.js
+++ b/src/pages/admin/categories/CategoryHierarchy/index.js
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, Fragment } from 'react';
+import { Link } from 'react-router-dom';
+import { useToast } from '../../../../hooks/useToast';
+import ListGroup from 'react-bootstrap/ListGroup';
+import Spinner from 'react-bootstrap/Spinner';
+import CategoryApi from '../../../../api/Category';
+import { GoKebabVertical } from 'react-icons/go';
+import { RiArrowRightSLine } from 'react-icons/ri';
+import style from './index.module.scss';
+
+const CategoryHierarchy = () => {
+  const toast = useToast();
+  const [categories, setCategories] = useState();
+  const [chosenCategoryPathID, setChosenCategoryPathID] = useState(null);
+  const [breadcrumbs, setBreadCrumbs] = useState([]);
+
+  useEffect(() => {
+    console.log(breadcrumbs);
+    setCategories(null);
+    chosenCategoryPathID ? toast('Processing', 'Getting Subcategories...') : '';
+
+    CategoryApi.getCategories({ category_id: chosenCategoryPathID })
+      .then(({ data }) => {
+        setCategories(data.data);
+      })
+      .catch(() =>
+        toast('Error', 'There was an error getting the list of categories.')
+      );
+  }, [chosenCategoryPathID]);
+
+  const onCategoryClick = (category, index) => {
+    if (category.subcategories_count > 0) {
+      setChosenCategoryPathID(category.id);
+      setBreadCrumbs([
+        ...breadcrumbs,
+        { id: category.id, name: category.name, idx: index }
+      ]);
+    } else {
+      toast('Message', 'This category does not have a subcategory.');
+    }
+  };
+
+  const onBreadcrumbClick = (category_id, index) => {
+    console.log(breadcrumbs);
+    setBreadCrumbs(breadcrumbs.slice(0, index + 1));
+    setChosenCategoryPathID(category_id);
+  };
+
+  return (
+    <div className={style.mainContent}>
+      <div>
+        <div className={style.breadcrumbsContainer}>
+          <span>Category Hierarchy</span>
+          <RiArrowRightSLine className={style.breadcrumbArrowIcon} />
+          <span
+            className={style.breadcrumbs}
+            onClick={() => {
+              setChosenCategoryPathID(null);
+              setBreadCrumbs([]);
+            }}
+          >
+            Root
+          </span>
+          {breadcrumbs?.map((breadcrumb, idx) => {
+            return (
+              <Fragment key={idx}>
+                <RiArrowRightSLine className={style.breadcrumbArrowIcon} />
+                <span
+                  className={style.breadcrumbs}
+                  onClick={() => {
+                    onBreadcrumbClick(breadcrumb.id, idx);
+                  }}
+                >
+                  {breadcrumb.name}
+                </span>
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+      <ListGroup>
+        {categories ? (
+          categories?.map((category, idx) => {
+            return (
+              <ListGroup.Item
+                key={idx}
+                className={style.listItems}
+                onClick={() => {
+                  onCategoryClick(category, idx);
+                }}
+              >
+                <Link to={`/admin/edit-category/${category.id}`}>
+                  <span className={style.categoryName}>{category.name}</span>
+                </Link>
+                <GoKebabVertical />
+              </ListGroup.Item>
+            );
+          })
+        ) : (
+          <div className={style.spinner}>
+            <Spinner animation="border" />
+            <span>Loading</span>
+          </div>
+        )}
+      </ListGroup>
+    </div>
+  );
+};
+
+export default CategoryHierarchy;

--- a/src/pages/admin/categories/CategoryHierarchy/index.module.scss
+++ b/src/pages/admin/categories/CategoryHierarchy/index.module.scss
@@ -1,0 +1,79 @@
+@use '../../../../styles/variables' as *;
+
+@mixin flex($justify-value, $align-value, $direction, $gap-value) {
+  display: flex;
+  align-items: $align-value;
+  justify-content: $justify-value;
+  flex-direction: $direction;
+  gap: $gap-value;
+}
+
+.mainContent {
+  position: absolute;
+  height: 100%;
+  width: calc(100% - 300px);
+  left: 300px;
+  padding: 40px;
+
+  overflow: auto;
+  overflow-x: hidden;
+
+  @include flex(none, none, column, 35px);
+}
+
+.breadcrumbsContainer {
+  font-weight: $font-weight-medium;
+  font-size: $font-size-page-title;
+  color: #697582;
+  width: 100%;
+
+  white-space: nowrap;
+  overflow: scroll;
+  overflow-y: hidden;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    height: 0px;
+  }
+}
+
+.breadcrumbArrowIcon {
+  margin: 0px 7px;
+}
+
+.listItems {
+  padding: 20px;
+  cursor: pointer;
+
+  @include flex(space-between, center, row, 0px);
+
+  &:hover {
+    background-color: $color-light-blue-1;
+  }
+}
+
+.breadcrumbs {
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:last-child {
+    text-decoration: none;
+    color: $color-black;
+    cursor: default;
+  }
+}
+
+.categoryName {
+  color: $color-dark-blue-1;
+
+  &:hover {
+    color: $color-black;
+    font-weight: $font-weight-medium;
+  }
+}
+
+.spinner {
+  height: 700px;
+
+  @include flex(center, center, row, 10px);
+}

--- a/src/pages/admin/categories/CategoryHierarchy/index.module.scss
+++ b/src/pages/admin/categories/CategoryHierarchy/index.module.scss
@@ -48,7 +48,7 @@
   @include flex(space-between, center, row, 0px);
 
   &:hover {
-    background-color: $color-light-blue-1;
+    background-color: $color-white-4;
   }
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,6 +19,7 @@ import AdminProfile from '../pages/admin/profile/Profile';
 import AdminEditProfile from '../pages/admin/profile/EditProfile';
 import AdminEditPassword from '../pages/admin/profile/EditPassword';
 import AdminList from '../pages/admin/Admin/AdminList';
+import AdminCategoryHierarchy from '../pages/admin/categories/CategoryHierarchy';
 
 // Student Components
 import Login from '../pages/student/main/Login';
@@ -115,6 +116,12 @@ const Routes = () => {
       ></AdminRoute>
 
       <AdminRoute path="/admin/users" exact component={AdminList}></AdminRoute>
+
+      <AdminRoute
+        path="/admin/category-hierarchy"
+        exact
+        component={AdminCategoryHierarchy}
+      ></AdminRoute>
 
       {/* STUDENT ROUTES */}
       <AuthRoute path="/login" exact component={Login}></AuthRoute>

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,6 +1,7 @@
 $color-white: #ffffff;
 $color-white-2: #f5f5f5;
 $color-white-3: #fafafa;
+$color-white-4: #f3f3f3;
 $color-black: #000000;
 $color-incorrect: rgb(112, 0, 0);
 $color-correct: rgb(0, 102, 0);


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-303

### Definition of Done
* [x] Design is the same as the Figma design
* [x] Parent categories are displayed above the list
* [x] Clicking on one category will redirect to a page with all its subcategories
* [x] If subcategory text is too long, make it scrollable
* [x] (Low Prio) Make the breadcrumb headers clickable so that the user can go "back"

### Notes
#### Main note, 
- The kebab menu is not included in this task.

- The Add/Edit Category Form is not in its original position [refer to below screenshot], so I had to make changes in its CSS file to fix that, please double check on your end as well.

> ![image](https://user-images.githubusercontent.com/91049234/157154007-fc04716e-d42d-4cc0-8830-d6adc77b2e24.png)


#### Pages Affected
- Category Hierarchy: http://localhost:3003/admin/category-hierarchy

### Screenshots
Category Hierarchy
> ![CATEGORY HIERARCHY](https://user-images.githubusercontent.com/91049234/157156511-58adc720-b122-4522-9291-a8a56e51d71d.gif)

Fixed the position of the Add/Edit Category Form
> ![image](https://user-images.githubusercontent.com/91049234/157154198-2886cf66-8579-4a07-8f24-1bab099bb220.png)
