### PR TITLE
E_CLASSROOM-309 [Bugfix] [Student] Cannot upload photo unless refresh

### DIFF
--- a/src/pages/student/profile/ProfileDetail/index.js
+++ b/src/pages/student/profile/ProfileDetail/index.js
@@ -48,6 +48,9 @@ const ProfileDetail = () => {
       setStatus(true);
       StudentApi.getDetails(loggedInUserId).then(({ data }) => {
         setAvatar(data.avatar);
+        setStatus(false);
+        setModalShow(false);
+        setError(false);
       });
     } catch (error) {
       if (error?.response?.data?.errors) {


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-309
### Definition of Done
- [x] User should be able to upload without refreshing the page

### Commands to Run


### Notes
#### Main note
- http://localhost:3003/profile
#### Pages Affected
- N/A

### Scenarios/ Test Cases
- [ ] User can reupload without refresh the page
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![studentupload](https://user-images.githubusercontent.com/89514595/157417185-94058808-db31-4742-b3bf-9a8f017f572d.gif)

