### PR TITLE
E_CLASSROOM-308 (Dependent on #303) [FE/BE] Breadcrumbs for Hierarchy Page

### DIFF
--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -43,7 +43,10 @@ const AddEditCategory = () => {
   }, [location, isSaved]);
 
   useEffect(() => {
-    if (categoryViewType === 'Hierarchy') {
+    if (
+      categoryViewType === 'Hierarchy' &&
+      loc.pathname === '/admin/add-category'
+    ) {
       getParentCategories();
       setParentCategoryID(categoryID);
     } else if (loc.pathname !== '/admin/add-category') {
@@ -122,7 +125,11 @@ const AddEditCategory = () => {
       CategoryApi.update(name, description, parentCategoryID, category_id)
         .then(() => {
           toast('Success', 'Successfully Updated Category.');
-          history.push('/admin/categories');
+          categoryViewType === 'Hierarchy'
+            ? history.push(
+                `/admin/category-hierarchy?categoryID=${category_id}`
+            )
+            : history.push('/admin/categories');
         })
         .catch((error) => detectTypo(error));
     } else {

--- a/src/pages/admin/categories/CategoryHierarchy/index.js
+++ b/src/pages/admin/categories/CategoryHierarchy/index.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, Fragment } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import { GoKebabVertical } from 'react-icons/go';
-import { RiArrowRightSLine } from 'react-icons/ri';
+import { CgFormatSlash } from 'react-icons/cg';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Dropdown from 'react-bootstrap/Dropdown';
 import Spinner from 'react-bootstrap/Spinner';
@@ -11,10 +11,11 @@ import style from './index.module.scss';
 
 const CategoryHierarchy = () => {
   const toast = useToast();
+  const history = useHistory();
   const queryParams = new URLSearchParams(window.location.search);
   const categoryID = queryParams.get('categoryID');
   const [categories, setCategories] = useState();
-  const [chosenCategoryPathID, setChosenCategoryPathID] = useState(null);
+  const [chosenCategoryPathID, setChosenCategoryPathID] = useState(categoryID);
   const [breadcrumbs, setBreadcrumbs] = useState([]);
 
   useEffect(() => {
@@ -23,7 +24,7 @@ const CategoryHierarchy = () => {
       ? toast('Processing', 'Getting the subcategories...')
       : toast('Processing', 'Getting the root categories...');
 
-    if (categoryID && !chosenCategoryPathID) {
+    if (categoryID) {
       getParentCategories();
     }
 
@@ -32,7 +33,7 @@ const CategoryHierarchy = () => {
 
   const load = () => {
     CategoryApi.getCategories({
-      category_id: chosenCategoryPathID || categoryID
+      category_id: chosenCategoryPathID
     })
       .then(({ data }) => {
         setCategories(data.data);
@@ -46,6 +47,7 @@ const CategoryHierarchy = () => {
     CategoryApi.getParentCategories(categoryID)
       .then(({ data }) => {
         setBreadcrumbs(data);
+        history.replace({ categoryID });
       })
       .catch((error) => toast('Error', error));
   };
@@ -69,10 +71,13 @@ const CategoryHierarchy = () => {
 
   return (
     <div className={style.mainContent}>
-      <div>
+      <section className={style.headerSection}>
+        <span className={style.pageTitle}>Category Hierarchy</span>
         <div className={style.breadcrumbsContainer}>
-          <span>Category Hierarchy</span>
-          <RiArrowRightSLine className={style.breadcrumbArrowIcon} />
+          <span className={style.breadcrumbs}>Categories</span>
+          <CgFormatSlash size={20} />
+          <span className={style.breadcrumbs}>Hierarchy View</span>
+          <CgFormatSlash size={20} />
           <span
             className={style.breadcrumbs}
             onClick={() => {
@@ -85,7 +90,10 @@ const CategoryHierarchy = () => {
           {breadcrumbs?.map((breadcrumb, idx) => {
             return (
               <Fragment key={idx}>
-                <RiArrowRightSLine className={style.breadcrumbArrowIcon} />
+                <CgFormatSlash
+                  size={20}
+                  className={style.breadcrumbSlashIcon}
+                />
                 <span
                   className={style.breadcrumbs}
                   onClick={() => {
@@ -98,7 +106,7 @@ const CategoryHierarchy = () => {
             );
           })}
         </div>
-      </div>
+      </section>
       <ListGroup>
         {categories ? (
           categories?.map((category, idx) => {
@@ -110,7 +118,9 @@ const CategoryHierarchy = () => {
                     onCategoryClick(category, idx);
                   }}
                 >
-                  <Link to={`/admin/edit-category/${category.id}`}>
+                  <Link
+                    to={`/admin/edit-category/${category.id}?categoryViewType=Hierarchy`}
+                  >
                     <span className={style.categoryName}>{category.name}</span>
                   </Link>
                 </div>

--- a/src/pages/admin/categories/CategoryHierarchy/index.module.scss
+++ b/src/pages/admin/categories/CategoryHierarchy/index.module.scss
@@ -18,12 +18,23 @@
   overflow: auto;
   overflow-x: hidden;
 
-  @include flex(none, none, column, 35px);
+  @include flex(none, none, column, 30px);
+}
+
+.headerSection {
+  @include flex(flex-start, flex-start, column, 5px);
+}
+
+.pageTitle {
+  font-weight: $font-weight-medium;
+  font-size: $font-size-page-title;
+  color: $color-dark-blue-1;
+  margin: 0px;
 }
 
 .breadcrumbsContainer {
   font-weight: $font-weight-medium;
-  font-size: $font-size-page-title;
+  font-size: $font-size-md;
   color: $color-gray;
   width: 100%;
 
@@ -35,10 +46,6 @@
   &::-webkit-scrollbar {
     height: 0px;
   }
-}
-
-.breadcrumbArrowIcon {
-  margin: 0px 7px;
 }
 
 .listItems {
@@ -56,10 +63,16 @@
   text-decoration: underline;
   cursor: pointer;
 
+  &:first-child,
+  &:nth-child(3) {
+    text-decoration: none;
+    cursor: default;
+  }
+
   &:last-child {
     text-decoration: none;
-    color: $color-black;
     cursor: default;
+    color: black;
   }
 }
 


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-308

### Definition of Done
* [x] Breadcrumb UI should be the same as the Figma design
* [x] Should start with "Categories / Hierarchy View / Root"
* [x] Append the Category name after "...Root"
* [x] Clicking on "Root" should redirect to the Root category display
* [x] Clicking on a category name should display the subcategories related to it

### Notes
#### Pages Affected
- http://localhost:3003/admin/category-hierarchy

### Screenshots
> ![NEW BREADCRUMBS UI](https://user-images.githubusercontent.com/91049234/157425101-2c78966a-fdb9-45ef-ac24-ca10dbc8caca.gif)