### PR TITLE
E_CLASSROOM-280 [FE/BE] Sort admin table by column

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -74,15 +74,13 @@ const DataTable = ({
               <td
                 className={titleHeaderStyle}
                 onClick={() => {
-                  if (header?.canSort){
+                  if (header?.canSort) {
                     onSortClick(header.title);
                   }
                 }}
                 key={idx}
               >
-                <div
-                  className={header?.canSort ? style.headerName : ''}
-                >
+                <div className={header?.canSort ? style.headerName : ''}>
                   <span>{header.title}</span>
                   <div>{renderArrowIcons(header.title)}</div>
                 </div>
@@ -93,7 +91,13 @@ const DataTable = ({
         </tr>
       </thead>
       {data ? (
-        <tbody>{renderTableData()}</tbody>
+        <tbody>
+          {data.length > 0 ? (
+            renderTableData()
+          ) : (
+            <span className={style.noResultsFound}>No Results Found</span>
+          )}
+        </tbody>
       ) : (
         <Button className={style.spinner} disabled>
           <Spinner animation="border" />

--- a/src/components/DataTable/index.module.scss
+++ b/src/components/DataTable/index.module.scss
@@ -22,10 +22,11 @@
   height: 27px;
 }
 
-.spinner {
+.spinner,
+.noResultsFound {
   position: absolute;
   height: 25px;
-  left: 760px;
+  left: 715px;
   top: 430px;
 
   @extend %flex-align-center;

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -31,25 +31,31 @@ const AdminList = () => {
   const [searchStatus, setSearchStatus] = useState(false);
   const [sortOptions, setSortOptions] = useState({
     sortBy,
-    sortDirection,
+    sortDirection
   });
 
   const tableHeaderNames = [
-    { title: 'ID' },
-    { title: 'Name' },
-    { title: 'Email' },
+    { title: 'ID', canSort: true },
+    { title: 'Name', canSort: true },
+    { title: 'Email', canSort: true }
   ];
 
   useEffect(() => {
-    history.push(`?page=${page}&search=${search}`);
+    history.push(
+      `?page=${page}&search=${search}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
+    );
+
+    setAdminAccounts(null);
 
     load();
-  }, [page, searchStatus]);
+  }, [page, searchStatus, sortOptions]);
 
   const load = () => {
-    AdminApi.getAdminAccounts({ 
+    AdminApi.getAdminAccounts({
       page,
-      search
+      search,
+      sortBy: sortOptions.sortBy,
+      sortDirection: sortOptions.sortDirection
     })
       .then(({ data }) => {
         setAdminAccounts(data.data);
@@ -71,7 +77,7 @@ const AdminList = () => {
 
   function onChangeData(e) {
     setSearch(e.target.value);
-    
+
     if (e.target.value.length === 0) {
       setPage(1);
       setSearchStatus(!searchStatus);


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-280

### Definition of Done
* [x] User should be able to sort by id, name, and email
* [x] Refreshing the page should keep the sort option
* [x] Arrow icon should be visible when the column is sorted 
* [x] the first click should sort by ascending
* [x] Second click on the same column, sort by descending
* [x] Third click on the same column, sort by default

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/70

### Notes
#### Main Note
- I included a No Results Found message since I notice that If I search for a user that does not exist it will just display nothing,
 
#### Pages Affected
- ADMIN LIST PAGE: http://localhost:3003/admin/users

### Screenshots
> ![admin sort by col app](https://user-images.githubusercontent.com/91049234/157577774-7c239efa-130c-4841-a7ad-37d74f93f178.gif)
