### PR TITLE
E_CLASSROOM-301 [FE/BE] [Admin] Filtering quizzes by name and category

### DIFF
--- a/src/api/Category/index.js
+++ b/src/api/Category/index.js
@@ -86,15 +86,6 @@ const CategoryApi = {
     return API.request(options);
   },
 
-  getUnpaginatedCategoryList: () => {
-    const options = {
-      method: 'GET',
-      url: '/admin/unpaginated-categories'
-    };
-
-    return API.request(options);
-  },
-
   delete: () => {},
 
   restore: () => {}

--- a/src/api/Category/index.js
+++ b/src/api/Category/index.js
@@ -86,6 +86,15 @@ const CategoryApi = {
     return API.request(options);
   },
 
+  getUnpaginatedCategoryList: () => {
+    const options = {
+      method: 'GET',
+      url: '/admin/unpaginated-categories'
+    };
+
+    return API.request(options);
+  },
+
   delete: () => {},
 
   restore: () => {}

--- a/src/components/DataTable/index.module.scss
+++ b/src/components/DataTable/index.module.scss
@@ -25,9 +25,9 @@
 .spinner,
 .noResultsFound {
   position: absolute;
-  height: 25px;
-  left: 715px;
-  top: 430px;
+  top: 450px;
+  left: 50%;
+  transform: translate(-50%, -50%);
 
   @extend %flex-align-center;
 

--- a/src/components/FilterDropdown/index.js
+++ b/src/components/FilterDropdown/index.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { PropTypes } from 'prop-types';
+import Dropdown from 'react-bootstrap/Dropdown';
+import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
+
+import style from './index.module.scss';
+
+/*
+    To use this component, pass the following props:
+    
+    > dropdownLabel : Pass a string value for the dropdown label.
+    
+    > dropdownItems : Pass an array of objects containing the name of the dropdown items
+
+                       e.g.  const items = [{name: 'Web Development'}, {name: 'Science'}];
+    
+    > isScrollable : Pass true if there are a lot of menu items to make the dropdown menu scrollable, 
+                     otherwise pass false and the dropdown menu height will adjust according to how many items there are.
+
+    > fillter      : Pass the filter value
+    
+    > setFilter    : Pass your setter function to set the filter value.
+*/
+
+const FilterDropdown = ({
+  dropdownLabel,
+  dropdownItems,
+  isScrollable,
+  filter,
+  setFilter
+}) => {
+  const [activeItem, setActiveItem] = useState(filter || 'All');
+  const [isClicked, setIsClicked] = useState(false);
+
+  return (
+    <Dropdown
+      onClick={() => {
+        if (dropdownItems?.length > 0) {
+          setIsClicked(!isClicked);
+        }
+      }}
+    >
+      <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
+        {filter || dropdownLabel}
+        {isClicked ? <IoIosArrowUp size={17} /> : <IoIosArrowDown size={17} />}
+      </Dropdown.Toggle>
+      {dropdownItems?.length ? (
+        <Dropdown.Menu
+          className={
+            isScrollable ? style.dropdownMenuScrollable : style.dropdownMenu
+          }
+        >
+          <Dropdown.Item
+            className={
+              activeItem === 'All' ? style.activeItem : style.dropdownItems
+            }
+            onClick={() => {
+              setActiveItem(-1);
+              setFilter('');
+            }}
+          >
+            All
+          </Dropdown.Item>
+          {dropdownItems?.map((item, idx) => {
+            return (
+              <Dropdown.Item
+                key={idx}
+                className={
+                  activeItem === item.name
+                    ? style.activeItem
+                    : style.dropdownItems
+                }
+                onClick={() => {
+                  setActiveItem(item.name);
+                  setFilter(item.name);
+                  setIsClicked(false);
+                }}
+              >
+                {item.name}
+              </Dropdown.Item>
+            );
+          })}
+        </Dropdown.Menu>
+      ) : (
+        ''
+      )}
+    </Dropdown>
+  );
+};
+
+FilterDropdown.propTypes = {
+  dropdownLabel: PropTypes.string,
+  dropdownItems: PropTypes.array,
+  isScrollable: PropTypes.bool,
+  filter: PropTypes.string,
+  setFilter: PropTypes.func
+};
+
+export default FilterDropdown;

--- a/src/components/FilterDropdown/index.module.scss
+++ b/src/components/FilterDropdown/index.module.scss
@@ -1,0 +1,62 @@
+@use '../../styles/variables' as *;
+
+%hover-style {
+  background-color: $color-light-blue-1;
+  color: $color-dark-blue-1;
+}
+
+%dropdown-menu-style {
+  width: auto;
+  border: 1px $color-light-blue-1 solid;
+}
+
+.dropdownButton {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 15px;
+
+  background-color: $color-white;
+  color: $color-dark-blue-1;
+  font-size: $font-size-md;
+  border: none;
+  height: 38px;
+  width: 215px;
+
+  &:hover,
+  &:focus {
+    background-color: $color-white;
+    color: $color-dark-blue-1;
+  }
+}
+
+.dropdownMenuScrollable {
+  height: 300px;
+
+  @extend %dropdown-menu-style;
+
+  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 5px;
+  }
+}
+
+.dropdownMenu {
+  @extend %dropdown-menu-style;
+}
+
+.dropdownItems {
+  color: $color-dark-blue-1;
+
+  &:hover,
+  &:focus {
+    @extend %hover-style;
+  }
+}
+
+.activeItem {
+  @extend %hover-style;
+}

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import Form from 'react-bootstrap/Form';
+import Button from 'react-bootstrap/Button';
+import { BiSearch } from 'react-icons/bi';
+
+import style from './index.module.scss';
+
+/*
+    To use this component, pass the following props:
+    
+    > onSearchSubmit      : Pass a function that will handle the search submit
+    
+    > onSearchValueChange : Pass a function that will handle everytime the search input value changes
+
+    > placeholder         : Pass a string value for the placeholder
+*/
+
+const SearchBar = ({ onSearchSubmit, onSearchValueChange, placeholder }) => {
+  return (
+    <Form className={style.searchSection} onSubmit={onSearchSubmit}>
+      <div className={style.searchInput}>
+        <Form.Control
+          className={style.searchBar}
+          type="text"
+          placeholder={placeholder}
+          onChange={onSearchValueChange}
+        />
+        <BiSearch size={17} className={style.searchIcon} />
+      </div>
+      <Button className={style.searchButton} type="submit">
+        Search
+      </Button>
+    </Form>
+  );
+};
+
+SearchBar.propTypes = {
+  onSearchSubmit: PropTypes.func,
+  onSearchValueChange: PropTypes.func,
+  placeholder: PropTypes.string
+};
+
+export default SearchBar;

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
@@ -7,22 +7,39 @@ import { BiSearch } from 'react-icons/bi';
 import style from './index.module.scss';
 
 /*
-    To use this component, pass the following props:
-    
-    > onSearchSubmit      : Pass a function that will handle the search submit
-    
-    > onSearchValueChange : Pass a function that will handle everytime the search input value changes
+    To use this component, pass these props:
 
-    > placeholder         : Pass a string value for the placeholder
+    > placeholder  : Pass a string value for the placeholder
+ 
+    > search       : Pass the search value
+
+    > setSearch    : To set the search value
 */
 
-const SearchBar = ({ onSearchSubmit, onSearchValueChange, placeholder }) => {
+const SearchBar = ({ placeholder, search, setSearch }) => {
+  const [searchValue, setSearchValue] = useState(search);
+
+  const onSearchSubmit = (e) => {
+    e.preventDefault();
+
+    setSearch(searchValue);
+  };
+
+  const onSearchValueChange = (e) => {
+    setSearchValue(e.target.value);
+
+    if (e.target.value.length === 0) {
+      setSearch('');
+    }
+  };
+
   return (
     <Form className={style.searchSection} onSubmit={onSearchSubmit}>
       <div className={style.searchInput}>
         <Form.Control
           className={style.searchBar}
           type="text"
+          value={searchValue}
           placeholder={placeholder}
           onChange={onSearchValueChange}
         />
@@ -36,9 +53,9 @@ const SearchBar = ({ onSearchSubmit, onSearchValueChange, placeholder }) => {
 };
 
 SearchBar.propTypes = {
-  onSearchSubmit: PropTypes.func,
-  onSearchValueChange: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  search: PropTypes.string,
+  setSearch: PropTypes.func
 };
 
 export default SearchBar;

--- a/src/components/SearchBar/index.module.scss
+++ b/src/components/SearchBar/index.module.scss
@@ -1,0 +1,35 @@
+@use '../../styles/variables' as *;
+
+.searchSection {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.searchInput {
+  position: relative;
+}
+
+.searchBar {
+  width: 304px;
+  padding-right: 34px;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 92%;
+  top: 28%;
+}
+
+.searchButton {
+  background-color: $color-light-blue-2;
+  color: $color-dark-blue-1;
+  border: none;
+  width: 93px;
+  height: 38px;
+
+  &:hover {
+    background-color: $color-light-blue-3;
+    color: $color-white;
+  }
+}

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -34,7 +34,7 @@ const CategoryList = () => {
 
   const [sortOptions, setSortOptions] = useState({
     sortBy,
-    sortDirection,
+    sortDirection
   });
 
   useEffect(() => {
@@ -49,6 +49,7 @@ const CategoryList = () => {
       search: search,
       sortBy: sortOptions.sortBy,
       sortDirection: sortOptions.sortDirection,
+      listCondition: 'paginated'
     }).then(({ data }) => {
       setCategories(data.data);
       setPerPage(data.per_page);
@@ -65,7 +66,7 @@ const CategoryList = () => {
     { title: 'ID', canSort: true },
     { title: 'Name', canSort: true },
     { title: 'Description', canSort: false },
-    { title: 'Edit', canSort: false },
+    { title: 'Edit', canSort: false }
   ];
 
   const renderTableData = () => {

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -43,7 +43,6 @@ const QuizList = () => {
   const [lastPage, setLastPage] = useState(0);
   const [filter, setFilter] = useState(filterVal ? filterVal : '');
   const [search, setSearch] = useState(searchVal ? searchVal : '');
-  const [searchStatus, setSearchStatus] = useState(false);
   const [sortOptions, setSortOptions] = useState({
     sortBy,
     sortDirection
@@ -74,7 +73,9 @@ const QuizList = () => {
   const load = () => {
     setAdminQuiz(null);
 
-    CategoryApi.getUnpaginatedCategoryList()
+    CategoryApi.listOfCategories({
+      listCondition: 'unpaginated'
+    })
       .then(({ data }) => {
         setCategories(data.data);
       })
@@ -102,31 +103,15 @@ const QuizList = () => {
 
   useEffect(() => {
     history.push(
-      `?page=${page}&search${search}&filter=${filter}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
+      `?page=${page}&search=${search}&filter=${filter}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
     );
 
     load();
-  }, [page, sortOptions, searchStatus, filter]);
+  }, [page, sortOptions, search, filter]);
 
   useEffect(() => {
     setPage(1);
-  }, [filter]);
-
-  const onSearchSubmit = (e) => {
-    e.preventDefault();
-
-    setPage(1);
-    setSearchStatus(!searchStatus);
-  };
-
-  const onSearchValueChange = (e) => {
-    setSearch(e.target.value);
-
-    if (e.target.value.length === 0) {
-      setPage(1);
-      setSearchStatus(!searchStatus);
-    }
-  };
+  }, [filter, search]);
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
@@ -167,9 +152,9 @@ const QuizList = () => {
           <Card className={style.mainCard}>
             <Card.Header className={style.cardHeader}>
               <SearchBar
-                onSearchSubmit={onSearchSubmit}
-                onSearchValueChange={onSearchValueChange}
                 placeholder="Filter by name"
+                search={search}
+                setSearch={setSearch}
               />
               <FilterDropdown
                 dropdownLabel={'Filter by Category'}

--- a/src/pages/admin/quizzes/QuizList/index.module.scss
+++ b/src/pages/admin/quizzes/QuizList/index.module.scss
@@ -56,44 +56,6 @@
   @include flex(space-between, none, row, 0px);
 }
 
-.searchSection {
-  @include flex(none, center, row, 10px);
-}
-
-.searchInput {
-  position: relative;
-}
-
-.searchBar {
-  width: 335px;
-  padding-right: 34px;
-}
-
-.searchIcon {
-  position: absolute;
-  left: 92%;
-  top: 28%;
-}
-
-.searchButton {
-  @include button-style($color-light-blue-2, 93px, 38px);
-
-  &:hover {
-    background-color: $color-light-blue-3;
-    color: $color-white;
-  }
-}
-
-.dropdownButton {
-  @include flex(center, center, row, 10px);
-  @include button-style($color-white, 93px, 38px);
-
-  &:hover {
-    background-color: $color-white;
-    color: $color-dark-blue-1;
-  }
-}
-
 .title {
   padding: 0px 0px 33px;
   font-weight: $font-weight-medium;


### PR DESCRIPTION
### Issue Link

https://framgiaph.backlog.com/view/E_CLASSROOM-301

### Definition of Done
* [x] Follow the design of the filtering function in Figma, please follow pixel perfect
* [x] Same behavior of name search in categories name search
* [x] For category dropdown behavior, once a Category is selected, display all quizzes related to that category

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/71

### Notes
#### Main Note
- Created a reusable component for the Filter Dropdown and Search Section [Search Input and Button]
#### Pages Affected
- Quiz List Page: http://localhost:3003/admin/quizzes

### Scenarios/ Test Cases
* [x] After clicking a filter, the chosen filter should already be the label of the dropdown
* [x] The chosen filtered should be highlighted every time a user opens the dropdown menu 
* [x] Can search quizzes by name
* [x] When the search value is not a complete word, any quizzes that match the letters in the search value should be returned
- [x] When filtering the quizzes, the user can only search quizzes under that filtered list
* [x] For category dropdown behavior, once a Category is selected, it should display the quizzes under that category.
* [x] There should be a `No Results Found` message if there are no quizzes found in that category or that matches that search value 

### Screenshots
> ![SEARCH AND FILTER QUIZZES PAGE](https://user-images.githubusercontent.com/91049234/157621741-56f37595-e6e8-4a37-9b46-6dab2630d8be.gif)
