### PR TITLE
E_CLASSROOM-311 [Admin] Move Action Buttons

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -14,13 +14,21 @@ import style from './index.module.scss';
                 otherwise it will return default button.
                 
     > disabled: Pass disabled if you want to have a disable button.
+
+    >type : Pass a string for a type of button
+            example type = "submit"
+    
+    >buttonStyle : will take the any style.
 */
 
 const ButtonComponent = ({
   buttonLabel,
   buttonSize,
   disabled,
-  outline = false
+  outline = false,
+  type,
+  onClick,
+  buttonStyle
 
 }) => {
 
@@ -41,7 +49,11 @@ const ButtonComponent = ({
 
   return (
     <div>
-      <Button className={`${style.defaultButton} ${sizeButton()} ${isOutline()}`} disabled={disabled} >
+      <Button className={`${style.defaultButton} ${sizeButton()} ${isOutline()} ${buttonStyle}`} 
+        disabled={disabled} 
+        type={type}
+        onClick={onClick}
+      >
         {buttonLabel}
       </Button>
     </div>
@@ -52,7 +64,10 @@ ButtonComponent.propTypes = {
   buttonLabel: PropTypes.string,
   buttonSize: PropTypes.string,
   disabled: PropTypes.bool,
-  outline: PropTypes.bool
+  outline: PropTypes.bool,
+  type: PropTypes.string,
+  onClick: PropTypes.func,
+  buttonStyle: PropTypes.any,
 };
 
 export default ButtonComponent;

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -87,7 +87,6 @@ const DataTable = ({
               </td>
             );
           })}
-          <td className={titleHeaderStyle}>Delete</td>
         </tr>
       </thead>
       {data ? (

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import Form from 'react-bootstrap/Form';
-import Button from 'react-bootstrap/Button';
+import Button from '../../components/Button';
 import { BiSearch } from 'react-icons/bi';
 
 import style from './index.module.scss';
@@ -45,9 +45,7 @@ const SearchBar = ({ placeholder, search, setSearch }) => {
         />
         <BiSearch size={17} className={style.searchIcon} />
       </div>
-      <Button className={style.searchButton} type="submit">
-        Search
-      </Button>
+      <Button buttonLabel="Search" buttonSize="sm" type="submit"/>
     </Form>
   );
 };

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -1,17 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Card from 'react-bootstrap/Card';
-import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
+import Button from '../../../../components/Button';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { VscFilter } from 'react-icons/vsc';
-import { BiSearch } from 'react-icons/bi';
-import { RiDeleteBin2Fill } from 'react-icons/ri';
 import Pagination from '../../../../components/Pagination';
 import DataTable from '../../../../components/DataTable';
 import AdminApi from '../../../../api/Admin';
 import style from './index.module.scss';
+import { BiSearch } from 'react-icons/bi';
 
 const AdminList = () => {
   const queryParams = new URLSearchParams(window.location.search);
@@ -36,6 +35,7 @@ const AdminList = () => {
 
   const tableHeaderNames = [
     { title: 'ID', canSort: true },
+    { title: 'Action', canSort: false },
     { title: 'Name', canSort: true },
     { title: 'Email', canSort: true }
   ];
@@ -93,11 +93,11 @@ const AdminList = () => {
       return (
         <tr key={idx} className={style.tableDataRow}>
           <td className={style.tableData}>{admin.id}</td>
+          <td className={`${style.tableData}`}>
+            <Button buttonLabel="Delete" buttonSize="sm" outline={true}/>
+          </td>
           <td className={style.tableData}>{admin.name}</td>
           <td className={style.tableData}>{admin.email}</td>
-          <td className={`${style.tableData} ${style.buttonColumn}`}>
-            <RiDeleteBin2Fill size="25px" color="#db7771" />
-          </td>
         </tr>
       );
     });
@@ -105,8 +105,11 @@ const AdminList = () => {
 
   return (
     <div className={style.mainContent}>
-      <div>
+      <div className={style.headerTittleStyle}>
         <h1 className={style.pageTitle}>Admin Accounts</h1>
+        <Link to="/admin/create-admin-account">
+          <Button buttonLabel="Add an Admin" buttonSize="def"/> 
+        </Link>
       </div>
       <Card className={style.card}>
         <Card.Header className={style.cardHeader}>
@@ -122,9 +125,7 @@ const AdminList = () => {
               />
               <BiSearch size={17} className={style.searchIcon} />
             </div>
-            <Button className={style.searchButton} type="submit">
-              Search
-            </Button>
+            <Button className={style.searchButton} buttonSize="sm" buttonLabel="Search" type="submit" />
           </Form>
           <Dropdown>
             <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
@@ -134,7 +135,6 @@ const AdminList = () => {
           </Dropdown>
         </Card.Header>
         <Card.Body className={style.cardBody}>
-          <Button className={style.addAdminButton}>Add an Admin</Button>
           <DataTable
             tableHeaderNames={tableHeaderNames}
             renderTableData={renderTableData}

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -30,6 +30,13 @@
 .pageTitle {
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title;
+  padding-top: 2px;
+}
+
+.headerTittleStyle{
+  display: flex;
+  justify-content: space-between;
+  padding-top: 10px;
 }
 
 .card {
@@ -84,7 +91,7 @@
 }
 
 .cardBody {
-  padding: 20px;
+  padding: 0px 30px 30px 30px;
   overflow: auto;
   overflow-x: hidden;
 }
@@ -104,13 +111,19 @@
   font-weight: $font-weight-bold;
 
   &:first-child {
-    width: 110px;
+    width: 247px;
   }
 
-  &:last-child {
-    width: 110px;
-    text-align: center;
+  &:nth-child(2) {
+    width: 400px;
+    padding-right: 394px;
+    padding-left: 10px;
   }
+
+  &:nth-child(3) {
+    width: 432px;
+  }
+
 }
 
 .tableDataRow {
@@ -122,10 +135,10 @@
 
 .tableData {
   border-bottom-width: 0px !important;
-}
 
-.buttonColumn {
-  text-align: center;
+  &:nth-child(2) {
+    padding-left: 0px;
+  }
 }
 
 #pagPosition {

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import Card from 'react-bootstrap/Card';
 import Dropdown from 'react-bootstrap/Dropdown';
-import { FaRegEdit } from 'react-icons/fa';
-import { RiDeleteBin2Fill } from 'react-icons/ri';
 import Pagination from '../../../../components/Pagination';
 import { VscFilter } from 'react-icons/vsc';
 import Button from '../../../../components/Button';
@@ -63,9 +61,9 @@ const CategoryList = () => {
 
   const tableHeaderNames = [
     { title: 'ID', canSort: true },
+    { title: 'Action', canSort: false },
     { title: 'Name', canSort: true },
     { title: 'Description', canSort: false },
-    { title: 'Edit', canSort: false }
   ];
 
   const renderTableData = () => {
@@ -73,17 +71,19 @@ const CategoryList = () => {
       return (
         <tr key={idx}>
           <td id={style.tBodyStyle}>{category.id}</td>
+          <td id={style.tBodyStyle1}>
+            <td>
+              <Link to={`/admin/edit-category/${category.id}`}>
+                <Button buttonLabel="Edit" buttonSize="sm"/>
+              </Link>
+            </td>
+            <td>
+              <Button buttonLabel="Delete" buttonSize="sm" outline={true}/>
+            </td>
+          </td>
           <td id={style.tBodyStyle}>{category.name}</td>
           <td id={style.tBodyStyle} className={`${style.paragraphEllipsis}`}>
             {category.description}
-          </td>
-          <td id={style.tBodyStyle1}>
-            <Link to={`/admin/edit-category/${category.id}`}>
-              <FaRegEdit size="20px" color="black" />
-            </Link>
-          </td>
-          <td id={style.tBodyStyle1}>
-            <RiDeleteBin2Fill size="30px" color="#db7771" />
           </td>
         </tr>
       );
@@ -95,6 +95,9 @@ const CategoryList = () => {
       <div>
         <div className={style.headerTitle}>
           <p className={style.title}>Categories</p>
+          <Link to="/admin/add-category" className={style.addButton}>
+            <Button buttonLabel="Add Category" buttonSize="def"/>
+          </Link>
         </div>
         <Card className={style.mainCard}>
           <Card.Header className={style.cardHeader}>
@@ -111,9 +114,6 @@ const CategoryList = () => {
             </Dropdown>
           </Card.Header>
           <Card.Body className={style.cardBodyScroll}>
-            <Link to="/admin/add-category" className={style.addButton}>
-              <Button buttonLabel="Add Category" buttonSize="def"/>
-            </Link>
             <div>
               <DataTable
                 tableHeaderNames={tableHeaderNames}

--- a/src/pages/admin/categories/CategoryList/index.module.scss
+++ b/src/pages/admin/categories/CategoryList/index.module.scss
@@ -84,7 +84,7 @@
 }
 
 .title {
-  padding: 0px 0px 33px;
+  padding: 0px 0px 23px;
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title;
   margin: 0px;
@@ -97,7 +97,7 @@
 
 .cardBodyScroll {
   overflow-y: scroll;
-  padding: 30px;
+  padding: 0px 30px 30px 30px;
 }
 
 #tBodyStyle {
@@ -107,12 +107,23 @@
   &:nth-child(3) {
     padding-right: 88px;
     height: 74px;
+    padding-left: 60px
+  }
+
+  &:nth-child(4) {
+    height: 74px;
+    padding-left: 50px
   }
 }
 
 #tBodyStyle1 {
   @extend %style-table-body;
-  text-align: center;
+  align-items: center;
+  display: flex;
+  padding-top: 10px;
+  gap: 11px;
+  width: 0px;
+  margin-left: 60px;
 }
 
 .firstCol {
@@ -145,26 +156,25 @@
   @extend %style-table-head;
 
   &:nth-child(1) {
-    width: 153px;
+    width: 77.2px;
   }
 
   &:nth-child(2) {
-    width: 285px;
+    width: 10px;
+    text-align: center;
+    padding-right: 225px;
   }
 
   &:nth-child(3) {
-    width: 517px;
+    width: 250px;
+    padding-left: 60px
   }
 
   &:nth-child(4) {
-    width: 151px;
-    text-align: center;
+    width: 210px;
+    padding-left: 50px
   }
 
-  &:nth-child(5) {
-    width: 151px;
-    text-align: center;
-  }
 }
 
 .headerTitle {

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -3,10 +3,7 @@ import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Col from 'react-bootstrap/Col';
 import Card from 'react-bootstrap/Card';
-import Button from 'react-bootstrap/Button';
-import { FaRegEdit } from 'react-icons/fa';
-import { RiDeleteBin2Fill } from 'react-icons/ri';
-
+import Button from '../../../../components/Button';
 import Pagination from '../../../../components/Pagination';
 import DataTable from '../../../../components/DataTable';
 import AddQuizModal from './components/AddQuizModal';
@@ -119,9 +116,9 @@ const QuizList = () => {
 
   const tableHeaderNames = [
     { title: 'ID', canSort: true },
+    { title: 'Action', canSort: false },
     { title: 'Category', canSort: true },
-    { title: 'Name', canSort: true },
-    { title: 'Edit', canSort: false }
+    { title: 'Name', canSort: true }
   ];
 
   const renderTableData = () => {
@@ -129,16 +126,18 @@ const QuizList = () => {
       return (
         <tr key={idx}>
           <td id={style.classColumn}>{quiz.id}</td>
+          <td id={style.buttonColumn}>
+            <center>
+              <Link to={`/admin/quizzes/${quiz.id}`}>
+                <Button buttonLabel="Edit" buttonSize="sm"/>
+              </Link>
+            </center>
+            <center>
+              <Button buttonLabel="Delete" buttonSize="sm" outline={true}/>
+            </center>
+          </td>
           <td id={style.classColumn}>{quiz.name}</td>
           <td id={style.classColumn}>{quiz.title}</td>
-          <td id={style.buttonColumn}>
-            <Link to={`/admin/quizzes/${quiz.id}`}>
-              <FaRegEdit size="20px" color="black" />
-            </Link>
-          </td>
-          <td id={style.buttonColumn}>
-            <RiDeleteBin2Fill size="30px" color="#db7771" />
-          </td>
         </tr>
       );
     });
@@ -147,7 +146,15 @@ const QuizList = () => {
   return (
     <div className={style.cardContainer}>
       <div>
-        <p className={style.title}>Quizzes</p>
+        <div className={style.headerTittleStyle}>
+          <p className={style.title}>Quizzes</p>
+          <Button
+            buttonStyle={style.addButton}
+            onClick={() => setModalShow(true)}
+            buttonLabel="Add a Quiz"
+            buttonSize="def"
+          />
+        </div>
         <Col>
           <Card className={style.mainCard}>
             <Card.Header className={style.cardHeader}>
@@ -165,12 +172,6 @@ const QuizList = () => {
               />
             </Card.Header>
             <Card.Body className={style.cardBodyScroll}>
-              <Button
-                className={style.addButton}
-                onClick={() => setModalShow(true)}
-              >
-                Add a Quiz
-              </Button>
               <div>
                 <DataTable
                   tableHeaderNames={tableHeaderNames}

--- a/src/pages/admin/quizzes/QuizList/index.module.scss
+++ b/src/pages/admin/quizzes/QuizList/index.module.scss
@@ -57,21 +57,20 @@
 }
 
 .title {
-  padding: 0px 0px 33px;
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title;
   margin: 0px;
 }
 
+.headerTittleStyle{
+  display: flex;
+  justify-content: space-between;
+  padding-top: 10px;
+}
+
 .addButton {
   float: right;
-  margin: 10px 0px 30px;
-  @include button-style($color-light-blue-2, 172px, 38px);
-
-  &:hover {
-    background-color: $color-light-blue-3;
-    border-color: $color-light-blue-3;
-  }
+  margin: 0px 0px 30px;
 }
 
 .modalButton {
@@ -92,7 +91,7 @@
 
 .cardBodyScroll {
   overflow-y: scroll;
-  padding: 30px;
+  padding: 0px 30px 30px 30px;
 }
 
 #classColumn {
@@ -100,14 +99,23 @@
   color: $color-dark-blue-1;
 
   &:nth-child(3) {
-    padding-right: 88px;
     height: 74px;
+    padding-left: 60px
+  }
+
+  &:nth-child(4) {
+    padding-left: 50px
   }
 }
 
 #buttonColumn {
   @extend %style-table-body;
-  text-align: center;
+  align-items: center;
+  display: flex;
+  padding-top: 10px;
+  gap: 11px;
+  width: 0px;
+  margin-left: 60px;
 }
 
 #paginateStyle {
@@ -194,24 +202,22 @@
   @extend %style-table-head;
 
   &:nth-child(1) {
-    width: 153px;
+    width: 77.2px;
   }
 
   &:nth-child(2) {
-    width: 285px;
+    width: 10px;
+    text-align: center;
+    padding-right: 225px;
   }
 
   &:nth-child(3) {
-    width: 517px;
+    width: 250px;
+    padding-left: 60px
   }
 
   &:nth-child(4) {
-    width: 151px;
-    text-align: center;
-  }
-
-  &:nth-child(5) {
-    width: 151px;
-    text-align: center;
+    width: 210px;
+    padding-left: 50px
   }
 }


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-311

### Definition of Done

- [x] Action buttons are moved to after the ID column

- [x] Updated to buttons instead of icons

- [x] One column contains the two icons

- [x] Both are clickable and functioning (Some button is not functioning like Delete button because we doesn't implement it yet.)  

### Commands to Run
N/A

### Notes
- Target pages
Admin Users table
Categories table
Quizzes table
#### Main note
N/A
#### Pages Affected
- http://localhost:3003/admin/categories
- http://localhost:3003/admin/quizzes
- http://localhost:3003/admin/users

### Scenarios/ Test Cases
- [x] Action buttons are moved to after the ID column

- [x] Updated to buttons instead of icons

- [x] One column contains the two icons

- [x] Both are clickable and functioning (Some button is not functioning like Delete button because we doesn't implement it yet.)  
#### User Interface
N/A
#### User Experience 
- [ ] when the button is click there should be an action.
#### Functionality
- [ ] Button should be redirect after clicking 
### Screenshots
![image](https://user-images.githubusercontent.com/89382909/158510250-77510395-ed2f-482d-b4ae-f38d1e438a4f.png)

![image](https://user-images.githubusercontent.com/89382909/158510283-4c2da9e0-9ba1-4203-a0d0-ac97f7f101b1.png)

![image](https://user-images.githubusercontent.com/89382909/158510312-63fcf8fe-e02e-4c07-93fb-f0a4be6e98f0.png)
