### PR TITLE
E_CLASSROOM-324 [FE/BE] Display related subcategories and quizzes for the selected category

### DIFF
--- a/src/api/Quiz/index.js
+++ b/src/api/Quiz/index.js
@@ -64,7 +64,25 @@ const QuizApi = {
     };
 
     return API.request(options);
-  }
+  },
+
+  categoryQuizzes: ({categoryId, ...params}) => {
+    const options = {
+      method: 'GET',
+      url: `/categories/${categoryId}/categoryQuizzes`,
+      params: {
+        ...params
+      }
+    };
+
+    return API.request(options);
+  },
+
+  store: () => {},
+
+  update: () => {},
+
+  delete: () => {},
 };
 
 export default QuizApi;

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card } from 'react-bootstrap';
 import { PropTypes } from 'prop-types';
 import { BsClockHistory } from 'react-icons/bs';
+import Col from 'react-bootstrap/Col';
 
 import style from './index.module.scss';
 import QuizzesTakenReviewApi from '../../../../../../api/QuizTakenReview';
@@ -58,53 +59,51 @@ const QuizzesCard = ({ quiz }) => {
   };
 
   return (
-    <Card className={style.carddiv}>
-      <Card.Header className={style.card} style={{ cursor: 'pointer' }}>
-        <div className={style.cardTitle}>
-          <span
-            style={{ fontWeight: 'bold', fontSize: '18px', color: '#48535B' }}
-          >
-            {quiz?.title}
-          </span>
-          <span
-            style={{ fontSize: '12px', color: '#48535B', marginTop: '5px' }}
-          >
-            <BsClockHistory
-              size="15px"
-              style={{
-                marginTop: '0px',
-                marginRight: '3px',
-                paddingBottom: '3px',
-              }}
-            />
-            {getTotalTimeLimit()} secs
-          </span>
-        </div>
-      </Card.Header>
-      <Card.Body className={style.card02} style={{ cursor: 'pointer' }}>
-        <div className={style.ResultscoreCardText}>
-          <div className={style.ResultScore}>
-            <p>Attempts</p>
-            <p>{QuizzesRecentReview?.length}</p>
+    <Col className={style.containerCard}>
+      <Card className={style.carddiv}>
+        <Card.Header className={style.card}>
+          <div className={style.cardTitle}>
+            <span
+              className={style.titleHeader}
+            >
+              {quiz?.title}
+            </span>
+            <span
+              className={style.clockHeader}
+            >
+              <BsClockHistory
+                size="15px"
+                className={style.clockIcon}
+              />
+              {getTotalTimeLimit()} secs
+            </span>
           </div>
-          <div className={style.ResultScore}>
-            <p>Highest Score</p>
-            <p>
-              {getHighestScore()}/{questions?.length}
-            </p>
+        </Card.Header>
+        <Card.Body className={style.card02} style={{ cursor: 'pointer' }}>
+          <div className={style.ResultscoreCardText}>
+            <div className={style.ResultScore}>
+              <p>Attempts</p>
+              <p>{QuizzesRecentReview?.length}</p>
+            </div>
+            <div className={style.ResultScore}>
+              <p>Highest Score</p>
+              <p>
+                {getHighestScore()}/{questions?.length}
+              </p>
+            </div>
+            <div className={style.ResultScore} style={{ fontWeight: 'bold' }}>
+              <p>Latest Score</p>
+              <p>
+                {getLatestScore() >= 0 ? getLatestScore() : 0}/{questions?.length}
+              </p>
+            </div>
           </div>
-          <div className={style.ResultScore} style={{ fontWeight: 'bold' }}>
-            <p>Latest Score</p>
-            <p>
-              {getLatestScore() >= 0 ? getLatestScore() : 0}/{questions?.length}
-            </p>
-          </div>
-        </div>
-      </Card.Body>
-      {quiz.answerCount === 0 || (
-        <div className={style.repeatDiv}>Take Quiz</div>
-      )}
-    </Card>
+        </Card.Body>
+        {quiz.answerCount === 0 || (
+          <div className={style.repeatDiv}>Take Quiz</div>
+        )}
+      </Card>
+    </Col>
   );
 };
 QuizzesCard.propTypes = {

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from 'react-bootstrap';
+import { PropTypes } from 'prop-types';
+import { BsClockHistory } from 'react-icons/bs';
+
+import style from './index.module.scss';
+import QuizzesTakenReviewApi from '../../../../../../api/QuizTakenReview';
+import QuestionApi from '../../../../../../api/Question';
+
+const QuizzesCard = ({ quiz }) => {
+  const [QuizzesRecentReview, setQuizzesRecentReview] = useState(null);
+  const [questions, setQuestions] = useState(null);
+
+  useEffect(() => { 
+    QuizzesTakenReviewApi.getAll(quiz.id).then(({ data }) => {
+      setQuizzesRecentReview(data.recentQuizzesTaken);
+    });
+
+    QuestionApi.getAll(quiz.id).then(({ data }) => {
+      setQuestions(data.data);
+    });
+  }, []);
+
+  const getHighestScore = () => {
+    if (QuizzesRecentReview?.length > 0) {
+      const highestScore = QuizzesRecentReview.reduce((prev, current) => {
+        return prev.score > current.score ? prev : current;
+      });
+
+      return highestScore.score;
+    }
+
+    return 0;
+  };
+
+  const getLatestScore = () => {
+    let score = -1;
+    if (QuizzesRecentReview?.length > 0) {
+      QuizzesRecentReview?.forEach((QuizRecent) => {
+        if (quiz.id === QuizRecent.quiz_id && score === -1) {
+          score = QuizRecent.score;
+        }
+      });
+
+      return score;
+    }
+  };
+
+  const getTotalTimeLimit = () => {
+    if (questions != null) {
+
+      const totalTimeLimit = questions.reduce((total, questions) => {
+        return (total += questions.time_limit);
+      }, 0);
+      return totalTimeLimit;
+      
+    }
+  };
+
+  return (
+    <Card className={style.carddiv}>
+      <Card.Header className={style.card} style={{ cursor: 'pointer' }}>
+        <div className={style.cardTitle}>
+          <span
+            style={{ fontWeight: 'bold', fontSize: '18px', color: '#48535B' }}
+          >
+            {quiz?.title}
+          </span>
+          <span
+            style={{ fontSize: '12px', color: '#48535B', marginTop: '5px' }}
+          >
+            <BsClockHistory
+              size="15px"
+              style={{
+                marginTop: '0px',
+                marginRight: '3px',
+                paddingBottom: '3px',
+              }}
+            />
+            {getTotalTimeLimit()} secs
+          </span>
+        </div>
+      </Card.Header>
+      <Card.Body className={style.card02} style={{ cursor: 'pointer' }}>
+        <div className={style.ResultscoreCardText}>
+          <div className={style.ResultScore}>
+            <p>Attempts</p>
+            <p>{QuizzesRecentReview?.length}</p>
+          </div>
+          <div className={style.ResultScore}>
+            <p>Highest Score</p>
+            <p>
+              {getHighestScore()}/{questions?.length}
+            </p>
+          </div>
+          <div className={style.ResultScore} style={{ fontWeight: 'bold' }}>
+            <p>Latest Score</p>
+            <p>
+              {getLatestScore() >= 0 ? getLatestScore() : 0}/{questions?.length}
+            </p>
+          </div>
+        </div>
+      </Card.Body>
+      {quiz.answerCount === 0 || (
+        <div className={style.repeatDiv}>Take Quiz</div>
+      )}
+    </Card>
+  );
+};
+QuizzesCard.propTypes = {
+  quiz: PropTypes.object,
+};
+
+export default QuizzesCard;

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -1,5 +1,11 @@
 @use '../../../../../../styles/variables' as *;
 
+.containerCard {
+    flex: 0;
+    width: auto;
+    padding-right: 0;
+}
+
 .card {
     color: $color-dark-blue-1;
     background-color:$color-light-blue-1;
@@ -8,56 +14,33 @@
     filter: drop-shadow(0 1mm 1mm #48535b8c);
     margin-bottom: 4px;
     padding: 10px 25px;
-  }
-  .card02 {
-    /* width: 385px; */
+    cursor: pointer;
+}
+
+.card02 {
     color: $color-dark-blue-1;
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
     height: 140px;
     padding-bottom: 0px;
-  
-  }
-  
-  .cardTitle {
+    cursor: pointer;
+}
+
+.cardTitle {
     display: flex;
     justify-content: space-between;
-  }
-  
-  /* .card.pass {
-    background-color: #c6f3bf;
-  }
-  
-  .card.pass:hover {
+}
+
+.card.fail {
+    background-color: $color-white-5;   
+}
+
+.card.fail:hover {
     background-color: $color-light-blue-7;
     color: $color-white;
-  } */
-  
-  .card.fail {
-    background-color: $color-white-5;
-  }
-  
-  .card.fail:hover {
-    background-color: $color-light-blue-7;
-    color: $color-white;
-  }
-  
-  /* .cardScore {
-    font-size: $font-size-base;
-    font-weight: $font-weight-light;
-  } */
-  
-  /* .image {
-    margin-right: 10px;
-  }
-  
-  .imageSize {
-    width: 35px;
-    height: 35px;
-    background-color: black;
-  } */
-  
-  .repeatDiv {
+}
+
+.repeatDiv {
     display: flex;
     justify-content: flex-end;
     padding-right: 25px;
@@ -66,36 +49,42 @@
     font-weight: bold;
     margin-top: 0px;
     font-size: $font-size-base;
-  }
-  
-  
-  
-  .ResultscoreCardText {
+}
+
+.ResultscoreCardText {
     padding: 10px 10px 0px 10px;
     margin-bottom: 0px;
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
     width: 308px;
-  }
-  
-  .ResultScore {
+}
+
+.ResultScore {
     display: flex;
     justify-content: space-between;
     margin-bottom: 0px;
     font-size: $font-size-base;
     font-weight: $font-weight-light;
-    /* width: 255px; */
-  }
-  
-  /* 
-  // <Card.Text
-  //   className={`${style.cardScore} d-flex justify-content-center`}
-  // >
-    {{`${quiz.correctAnswers}/${quiz.totalQuestions}`}}
-  {</Card.Text>} */
-  
-  
-  .carddiv{
+}
+
+.carddiv{
     width: 339px;
-  }
-  
+}
+
+.titleHeader {
+    font-weight: bold;
+    font-size: 18px;
+    color: $color-dark-blue-1;
+}
+
+.clockHeader {
+    font-size: 12px;
+    color: #48535B;
+    margin-top: 5px;
+}
+
+.clockIcon {
+    margin-top: 0px;
+    margin-right: 3px;
+    padding-bottom: 3px;
+}

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -1,0 +1,101 @@
+@use '../../../../../../styles/variables' as *;
+
+.card {
+    color: $color-dark-blue-1;
+    background-color:$color-light-blue-1;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+    filter: drop-shadow(0 1mm 1mm #48535b8c);
+    margin-bottom: 4px;
+    padding: 10px 25px;
+  }
+  .card02 {
+    /* width: 385px; */
+    color: $color-dark-blue-1;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    height: 140px;
+    padding-bottom: 0px;
+  
+  }
+  
+  .cardTitle {
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  /* .card.pass {
+    background-color: #c6f3bf;
+  }
+  
+  .card.pass:hover {
+    background-color: $color-light-blue-7;
+    color: $color-white;
+  } */
+  
+  .card.fail {
+    background-color: $color-white-5;
+  }
+  
+  .card.fail:hover {
+    background-color: $color-light-blue-7;
+    color: $color-white;
+  }
+  
+  /* .cardScore {
+    font-size: $font-size-base;
+    font-weight: $font-weight-light;
+  } */
+  
+  /* .image {
+    margin-right: 10px;
+  }
+  
+  .imageSize {
+    width: 35px;
+    height: 35px;
+    background-color: black;
+  } */
+  
+  .repeatDiv {
+    display: flex;
+    justify-content: flex-end;
+    padding-right: 25px;
+    color: $color-dark-blue-2;
+    margin-bottom: 9px;
+    font-weight: bold;
+    margin-top: 0px;
+    font-size: $font-size-base;
+  }
+  
+  
+  
+  .ResultscoreCardText {
+    padding: 10px 10px 0px 10px;
+    margin-bottom: 0px;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    width: 308px;
+  }
+  
+  .ResultScore {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0px;
+    font-size: $font-size-base;
+    font-weight: $font-weight-light;
+    /* width: 255px; */
+  }
+  
+  /* 
+  // <Card.Text
+  //   className={`${style.cardScore} d-flex justify-content-center`}
+  // >
+    {{`${quiz.correctAnswers}/${quiz.totalQuestions}`}}
+  {</Card.Text>} */
+  
+  
+  .carddiv{
+    width: 339px;
+  }
+  

--- a/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.js
+++ b/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Col from 'react-bootstrap/Col';
 import Card from 'react-bootstrap/Card';
 import { PropTypes } from 'prop-types';
 
@@ -7,30 +8,32 @@ import style from './index.module.css';
 
 const SubcategoryCard = ({ category, setChosenCategoryPathID }) => {
   return (
-    <Card className={style.card}>
-      <Card.Header id={style.cardHeader}>
-        <p className={style.cardTitle}>{category?.name}</p>
-        <p className={style.cardSubtitle}>{category?.description}</p>
-      </Card.Header>
-      <Card.Body>
-        <Link
-          to={
-            category?.subcategories_count
-              ? `/categories/${category.id}/sub`
-              : `/categories/${category.id}/quizzes`
-          }
-        >
-          <div
-            id={style.Subtitle}
-            onClick={() => setChosenCategoryPathID(category.id)}
+    <Col className={style.containerCard}>
+      <Card className={style.card}>
+        <Card.Header id={style.cardHeader}>
+          <p className={style.cardTitle}>{category?.name}</p>
+          <p className={style.cardSubtitle}>{category?.description}</p>
+        </Card.Header>
+        <Card.Body>
+          <Link
+            to={
+              category?.subcategories_count
+                ? `/categories/${category.id}/sub`
+                : `/categories/${category.id}/quizzes`
+            }
           >
-            {category?.subcategories_count
-              ? `View Available SubCategories: ${category?.subcategories_count}`
-              : 'Check Available Quizzes'}
-          </div>
-        </Link>
-      </Card.Body>
-    </Card>
+            <div
+              id={style.Subtitle}
+              onClick={() => setChosenCategoryPathID(category.id)}
+            >
+              {category?.subcategories_count
+                ? `View Available SubCategories: ${category?.subcategories_count}`
+                : 'Check Available Quizzes'}
+            </div>
+          </Link>
+        </Card.Body>
+      </Card>
+    </Col>
   );
 };
 

--- a/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.css
+++ b/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.css
@@ -12,6 +12,7 @@
 .card {
     height: 217px;
     width: 343px;
+    min-width: auto;
 }
 
 .cardTitle{
@@ -31,4 +32,10 @@
     font-size: 12px;
     font-weight: 500;
     color: #5D9098;
+}
+
+.containerCard {
+    flex: 0;
+    width: auto;
+    padding-right: 0;
 }

--- a/src/pages/student/categories/CategoryDetail/index.js
+++ b/src/pages/student/categories/CategoryDetail/index.js
@@ -4,6 +4,7 @@ import { useToast } from '../../../../hooks/useToast';
 import { LinkContainer } from 'react-router-bootstrap';
 import { BsFillArrowLeftSquareFill } from 'react-icons/bs';
 import Spinner from 'react-bootstrap/Spinner';
+import Row from 'react-bootstrap/Row';
 
 import Pagination from '../../../../components/Pagination';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
@@ -79,53 +80,6 @@ function Subcategories() {
     setQuizzesPage(selected + 1);
   };
 
-  // function Subcategories() {
-  //   const [categories, setCategories] = useState(null);
-  //   const [quizzes, setQuizzes] = useState(null);
-  //   const [category, setCategory] = useState(null);
-  //   const categoryId = useParams().id;
-  //   const queryParams = new URLSearchParams(window.location.search);
-  //   const pageNum = queryParams.get('page');
-  //   const history = useHistory();
-  //   const [categoryPage, setCategoryPage] = useState(pageNum ? pageNum : 1);
-  //   const [perCategoryPage, setPerCategoryPage] = useState(0);
-  //   const [totalCategoryItems, setTotalCategoryItems] = useState(0);
-  //   const [lastCategoryPage, setLastCategoryPage] = useState(0);
-  //   const [quizzesPage, setQuizzesPage] = useState(pageNum ? pageNum : 1);
-  //   const [perQuizzesPage, setPerQuizzesPage] = useState(0);
-  //   const [totalQuizzesItems, setTotalQuizzesItems] = useState(0);
-  //   const [lastQuizzesPage, setLastQuizzesPage] = useState(0);
-  //   const data = categories && quizzes;
-
-  //   useEffect(() => {
-  //     history.push(`/categories/${categoryId}/sub?page=${categoryPage}&page=${quizzesPage}`);
-
-  //     CategoryApi.show({ categoryId }).then(({ data }) => {
-  //       setCategory(data.data);
-  //       CategoryApi.getAll({ category_id: categoryId }, categoryPage).then(({ data }) => {
-  //         setCategories(data.data);
-  //         setPerCategoryPage(data.per_page);
-  //         setTotalCategoryItems(data.total);
-  //         setLastCategoryPage(data.last_page);
-  //       });
-  //       QuizApi.categoryQuizzes({ category_id: categoryId, quizzesPage }).then(({data}) => {
-  //         setQuizzes(data.data);
-  //         setPerQuizzesPage(data.per_page);
-  //         setTotalQuizzesItems(data.total);
-  //         setLastQuizzesPage(data.last_page);
-  //       });
-  //     });
-    
-  //   }, [categoryId, categoryPage, quizzesPage]);
-
-  // const onCategoryPageChange = (selected) => {
-  //   setCategoryPage(selected + 1);
-  // };
-
-  // const onQuizzesPageChange = (selected) => {
-  //   setQuizzesPage(selected + 1);
-  // };
-
   const renderCatList = () => {
     return categories.map((subcategory, idx) => {
       return (
@@ -142,6 +96,14 @@ function Subcategories() {
     return quizzes.map((quiz, idx) => {
       return <QuizzesCard quiz={quiz} key={idx}/>;
     });
+  };
+
+  const noResultMessage = (messageText) => {
+    return (
+      <div className={style.noResultsMessage}>
+        <p className={style.message}>{messageText}</p>
+      </div>
+    );
   };
 
   return (
@@ -170,18 +132,18 @@ function Subcategories() {
         </div>
       </div>
 
-      {data === null ? (
+      { !data ? (
         <div className={style.loading}>
           <Spinner animation="border" role="status"></Spinner>
           <span className={style.loadingWord}>Loading</span>
         </div>
       ) : (
         <div>
-          <div className={style.cardList}>{renderCatList()}</div>
+          <Row className={style.cardList}>
+            {renderCatList()}
+          </Row>
           {categories?.length <= 0 ? (
-            <div className={style.noResultsMessage}>
-              <p className={style.message}>NO RESULTS FOUND</p>
-            </div>
+            <div>{noResultMessage('NO RESULTS FOUND')}</div>
           ) : (
             <div className="pt-4">
               <Pagination
@@ -194,11 +156,11 @@ function Subcategories() {
             </div>
           )}
           <div className={style.header}>Quizzes</div>
-          <div className={style.cardList}>{renderQuizList()}</div>
+          <Row className={style.cardList}>
+            {renderQuizList()}
+          </Row>
           {quizzes?.length <= 0 ? (
-            <div className={style.noResultsMessage}>
-              <p className={style.message}>NO RELATED QUIZZES FOUND</p>
-            </div>
+            <div>{noResultMessage('NO RELATED QUIZZES FOUND')}</div>
           ) : (
             <div className="pt-4">
               <Pagination

--- a/src/pages/student/categories/CategoryDetail/index.js
+++ b/src/pages/student/categories/CategoryDetail/index.js
@@ -4,10 +4,13 @@ import { useToast } from '../../../../hooks/useToast';
 import { LinkContainer } from 'react-router-bootstrap';
 import { BsFillArrowLeftSquareFill } from 'react-icons/bs';
 import Spinner from 'react-bootstrap/Spinner';
+
 import Pagination from '../../../../components/Pagination';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import CategoryApi from '../../../../api/Category';
 import SubcategoryCard from './components/SubcategoryCard';
+import QuizzesCard from './components/QuizzesCard';
+import QuizApi from '../../../../api/Quiz';
 import style from './index.module.scss';
 
 function Subcategories() {
@@ -18,12 +21,18 @@ function Subcategories() {
   const pageNum = queryParams.get('page');
 
   const [categories, setCategories] = useState(null);
+  const [quizzes, setQuizzes] = useState(null);
   const [category, setCategory] = useState(null);
   const [chosenCategoryPathID, setChosenCategoryPathID] = useState(categoryId);
-  const [page, setPage] = useState(pageNum ? pageNum : 1);
-  const [perPage, setPerPage] = useState(0);
-  const [totalItems, setTotalItems] = useState(0);
-  const [lastPage, setLastPage] = useState(0);
+  const [categoryPage, setCategoryPage] = useState(pageNum ? pageNum : 1);
+  const [perCategoryPage, setPerCategoryPage] = useState(0);
+  const [totalCategoryItems, setTotalCategoryItems] = useState(0);
+  const [lastCategoryPage, setLastCategoryPage] = useState(0);
+  const [quizzesPage, setQuizzesPage] = useState(pageNum ? pageNum : 1);
+  const [perQuizzesPage, setPerQuizzesPage] = useState(0);
+  const [totalQuizzesItems, setTotalQuizzesItems] = useState(0);
+  const [lastQuizzesPage, setLastQuizzesPage] = useState(0);
+  const data = categories && quizzes;
 
   useEffect(() => {
     setCategories(null);
@@ -31,23 +40,30 @@ function Subcategories() {
     if (!chosenCategoryPathID) {
       history.push('/categories');
     } else {
-      history.push(`/categories/${chosenCategoryPathID}/sub?page=${page}`);
+      history.push(`/categories/${chosenCategoryPathID}/sub?page=${categoryPage}&page=${quizzesPage}`);
 
       load();
     }
-  }, [chosenCategoryPathID, page]);
+  }, [chosenCategoryPathID, categoryPage, quizzesPage]);
 
   const load = () => {
     CategoryApi.show({ categoryId: chosenCategoryPathID })
       .then(({ data }) => {
         setCategory(data.data);
-        CategoryApi.getAll({ category_id: chosenCategoryPathID }, page).then(
+        CategoryApi.getAll({ category_id: chosenCategoryPathID }, categoryPage).then(
           ({ data }) => {
             setCategories(data.data);
-            setPerPage(data.per_page);
-            setTotalItems(data.total);
-            setLastPage(data.last_page);
+            setPerCategoryPage(data.per_page);
+            setTotalCategoryItems(data.total);
+            setLastCategoryPage(data.last_page);
           }
+        );
+        QuizApi.categoryQuizzes({ category_id: categoryId, quizzesPage }).then(({data}) => {
+          setQuizzes(data.data);
+          setPerQuizzesPage(data.per_page);
+          setTotalQuizzesItems(data.total);
+          setLastQuizzesPage(data.last_page);
+        }
         );
       })
       .catch(() =>
@@ -55,9 +71,60 @@ function Subcategories() {
       );
   };
 
-  const onPageChange = (selected) => {
-    setPage(selected + 1);
+  const onCategoryPageChange = (selected) => {
+    setCategoryPage(selected + 1);
   };
+
+  const onQuizzesPageChange = (selected) => {
+    setQuizzesPage(selected + 1);
+  };
+
+  // function Subcategories() {
+  //   const [categories, setCategories] = useState(null);
+  //   const [quizzes, setQuizzes] = useState(null);
+  //   const [category, setCategory] = useState(null);
+  //   const categoryId = useParams().id;
+  //   const queryParams = new URLSearchParams(window.location.search);
+  //   const pageNum = queryParams.get('page');
+  //   const history = useHistory();
+  //   const [categoryPage, setCategoryPage] = useState(pageNum ? pageNum : 1);
+  //   const [perCategoryPage, setPerCategoryPage] = useState(0);
+  //   const [totalCategoryItems, setTotalCategoryItems] = useState(0);
+  //   const [lastCategoryPage, setLastCategoryPage] = useState(0);
+  //   const [quizzesPage, setQuizzesPage] = useState(pageNum ? pageNum : 1);
+  //   const [perQuizzesPage, setPerQuizzesPage] = useState(0);
+  //   const [totalQuizzesItems, setTotalQuizzesItems] = useState(0);
+  //   const [lastQuizzesPage, setLastQuizzesPage] = useState(0);
+  //   const data = categories && quizzes;
+
+  //   useEffect(() => {
+  //     history.push(`/categories/${categoryId}/sub?page=${categoryPage}&page=${quizzesPage}`);
+
+  //     CategoryApi.show({ categoryId }).then(({ data }) => {
+  //       setCategory(data.data);
+  //       CategoryApi.getAll({ category_id: categoryId }, categoryPage).then(({ data }) => {
+  //         setCategories(data.data);
+  //         setPerCategoryPage(data.per_page);
+  //         setTotalCategoryItems(data.total);
+  //         setLastCategoryPage(data.last_page);
+  //       });
+  //       QuizApi.categoryQuizzes({ category_id: categoryId, quizzesPage }).then(({data}) => {
+  //         setQuizzes(data.data);
+  //         setPerQuizzesPage(data.per_page);
+  //         setTotalQuizzesItems(data.total);
+  //         setLastQuizzesPage(data.last_page);
+  //       });
+  //     });
+    
+  //   }, [categoryId, categoryPage, quizzesPage]);
+
+  // const onCategoryPageChange = (selected) => {
+  //   setCategoryPage(selected + 1);
+  // };
+
+  // const onQuizzesPageChange = (selected) => {
+  //   setQuizzesPage(selected + 1);
+  // };
 
   const renderCatList = () => {
     return categories.map((subcategory, idx) => {
@@ -68,6 +135,12 @@ function Subcategories() {
           setChosenCategoryPathID={setChosenCategoryPathID}
         />
       );
+    });
+  };
+
+  const renderQuizList = () => {
+    return quizzes.map((quiz, idx) => {
+      return <QuizzesCard quiz={quiz} key={idx}/>;
     });
   };
 
@@ -95,42 +168,48 @@ function Subcategories() {
             </div>
           </p>
         </div>
-        <div id={style.quizlink}>
-          {category?.quizzes_count ? (
-            <a
-              className={style.linkToQuizzes}
-              href={`/categories/${category?.id}/quizzes`}
-            >
-              Check Available Quizzes &gt;&gt;
-            </a>
-          ) : (
-            ''
-          )}
-        </div>
       </div>
 
-      {categories === null ? (
+      {data === null ? (
         <div className={style.loading}>
           <Spinner animation="border" role="status"></Spinner>
           <span className={style.loadingWord}>Loading</span>
         </div>
       ) : (
-        <div className={style.cardList}>{renderCatList()}</div>
-      )}
-
-      {categories && categories?.length <= 0 ? (
-        <div className={style.noResultsMessage}>
-          <p className={style.message}>NO RESULTS FOUND</p>
-        </div>
-      ) : (
-        <div className="pt-4">
-          <Pagination
-            page={page}
-            perPage={perPage}
-            totalItems={totalItems}
-            pageCount={lastPage}
-            onPageChange={onPageChange}
-          ></Pagination>
+        <div>
+          <div className={style.cardList}>{renderCatList()}</div>
+          {categories?.length <= 0 ? (
+            <div className={style.noResultsMessage}>
+              <p className={style.message}>NO RESULTS FOUND</p>
+            </div>
+          ) : (
+            <div className="pt-4">
+              <Pagination
+                page={categoryPage}
+                perPage={perCategoryPage}
+                totalItems={totalCategoryItems}
+                pageCount={lastCategoryPage}
+                onPageChange={onCategoryPageChange}
+              ></Pagination>
+            </div>
+          )}
+          <div className={style.header}>Quizzes</div>
+          <div className={style.cardList}>{renderQuizList()}</div>
+          {quizzes?.length <= 0 ? (
+            <div className={style.noResultsMessage}>
+              <p className={style.message}>NO RELATED QUIZZES FOUND</p>
+            </div>
+          ) : (
+            <div className="pt-4">
+              <Pagination
+                page={quizzesPage}
+                perPage={perQuizzesPage}
+                totalItems={totalQuizzesItems}
+                pageCount={lastQuizzesPage}
+                onPageChange={onQuizzesPageChange}
+              ></Pagination>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/pages/student/categories/CategoryDetail/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/index.module.scss
@@ -57,11 +57,24 @@
 }
 
 .cardList {
-  display: grid;
-  grid-column-gap: 48px;
+  display: flex;
+  grid-column-gap: 34px;
   grid-row-gap: 48px;
-  grid-template-columns: 342px 342px 342px 342px;
-  grid-template-rows: 216px 216px 216px;
-  height: 747px;
   width: 1518px;
+
+  &:nth-child(4) {
+    grid-column-gap: 40px;
+  }
+}
+
+.noResultsMessage {
+  margin: 220px 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.message {
+  margin-left: 20px;
+  font-size: 24px;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -2,6 +2,7 @@ $color-white: #ffffff;
 $color-white-2: #f5f5f5;
 $color-white-3: #fafafa;
 $color-white-4: #f3f3f3;
+$color-white-5: #fad3d3;;
 $color-black: #000000;
 $color-gray: #697582;
 $color-light-gray: #b3b3b3;
@@ -14,6 +15,7 @@ $color-light-blue-3: #9abec1;
 $color-light-blue-4: #658286ad;
 $color-light-blue-5: #658286a9;
 $color-light-blue-6: #65828663;
+$color-light-blue-7: #789e98;
 
 $color-dark-blue-1: #48535b;
 $color-dark-blue-2: #5d9098;


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-324
### Definition of Done
- [x] When selecting a category page, create another section for quizzes below the subcategories
- [x] Display all quizzes related to that category
- If there's no related quizzes or subcategories, then put message "No related subcategories to show." or "No related quizzes to show." (or something alike)
- [x] Make API change if needed

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-be/pull/77
### Notes
#### Main note
- http://localhost:3003/categories/1/sub?page=1&page=1
#### Pages Affected
- Student subcategory page

### Scenarios/ Test Cases
- [ ] it should view the subcategory and quizzes related to that selected category
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![studentcatquiz](https://user-images.githubusercontent.com/89514595/158555746-5066a44e-2db9-487b-af45-e4433e77fb13.gif)

