### PR TITLE
E_CLASSROOM-328 [FE/BE] Delete for Quizzes and Admin Table

### DIFF
--- a/src/api/Admin/index.js
+++ b/src/api/Admin/index.js
@@ -59,6 +59,15 @@ const AdminApi = {
       }
     };
     return API.request(options);
+  },
+
+  deleteAdmin: (admin_id) => {
+    const options = {
+      method: 'DELETE',
+      url: `/admin/delete-admin/${admin_id}`
+    };
+
+    return API.request(options);
   }
 };
 

--- a/src/api/Quiz/index.js
+++ b/src/api/Quiz/index.js
@@ -5,9 +5,6 @@ const QuizApi = {
     const options = {
       method: 'GET',
       url: `/categories/${id}/quizzes?page=${pageNum}`
-      //   params: {
-      //   ...params,
-      // },
     };
 
     return API.request(options);
@@ -49,9 +46,7 @@ const QuizApi = {
   addQuiz: (name, instruction, location) => {
     const options = {
       method: 'POST',
-
       url: '/admin/add-quiz',
-
       data: {
         title: name,
         instruction: instruction,
@@ -62,13 +57,14 @@ const QuizApi = {
     return API.request(options);
   },
 
-  store: () => {},
+  deleteQuiz: (quiz_id) => {
+    const options = {
+      method: 'DELETE',
+      url: `/admin/delete-quiz/${quiz_id}`
+    };
 
-  update: () => {},
-
-  delete: () => {},
-
-  restore: () => {}
+    return API.request(options);
+  }
 };
 
 export default QuizApi;

--- a/src/components/ConfirmationModal/index.js
+++ b/src/components/ConfirmationModal/index.js
@@ -33,7 +33,7 @@ const ConfirmationModal = ({
       centered
     >
       <Modal.Header>
-        <Modal.Title id="contained-modal-title-vcenter">
+        <Modal.Title id="contained-modal-title-vcenter font-weight-bold">
           Confirm Deletion
         </Modal.Title>
       </Modal.Header>

--- a/src/components/ConfirmationModal/index.js
+++ b/src/components/ConfirmationModal/index.js
@@ -33,8 +33,8 @@ const ConfirmationModal = ({
       centered
     >
       <Modal.Header>
-        <Modal.Title id="contained-modal-title-vcenter font-weight-bold">
-          Confirm Deletion
+        <Modal.Title id="contained-modal-title-vcenter">
+          <b>Confirm Deletion</b>
         </Modal.Title>
       </Modal.Header>
       <Modal.Body className="p-4">

--- a/src/components/ConfirmationModal/index.js
+++ b/src/components/ConfirmationModal/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import Modal from 'react-bootstrap/Modal';
+import Button from '../Button';
+
+/*
+    To use this component, pass the following props:
+
+    showModal           :    pass the boolean value to determine whether to show or hide the modal.
+    setShowModal        :    pass the setter function of the state holding the boolean value.
+
+    basically you're just going to pass the state you defined that will hold the boolean value to determine whether to show or hide modal.
+
+    e.g.       const [showModal, ] = useState()
+
+               <Breadcrumbs showModal={showModal} setShowModal={setShowModal} />
+
+    itemToDelete         :    pass a string value such as the Quiz Name, Admin Name or Category Name of the item to be deleted to display in the modal.
+    setDeleteConfirmed   :    pass the setter function of the state holding the boolean value to determine whether to confirm deletion.
+*/
+
+const ConfirmationModal = ({
+  showModal,
+  setShowModal,
+  itemToDelete,
+  setDeleteConfirmed
+}) => {
+  return (
+    <Modal
+      show={showModal}
+      size="md"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header>
+        <Modal.Title id="contained-modal-title-vcenter">
+          Confirm Deletion
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="p-4">
+        <p>
+          Are you sure you want to permanently delete{' '}
+          <strong>{itemToDelete}</strong>?
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          buttonLabel="Cancel"
+          buttonSize="sm"
+          outline={true}
+          onClick={() => setShowModal(false)}
+        />
+        <Button
+          buttonLabel="Yes"
+          buttonSize="sm"
+          onClick={() => {
+            setDeleteConfirmed(true);
+            setShowModal(false);
+          }}
+        />
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+ConfirmationModal.propTypes = {
+  showModal: PropTypes.bool,
+  setShowModal: PropTypes.func,
+  itemToDelete: PropTypes.string,
+  setDeleteConfirmed: PropTypes.func
+};
+
+export default ConfirmationModal;

--- a/src/components/ConfirmationModal/index.js
+++ b/src/components/ConfirmationModal/index.js
@@ -11,7 +11,7 @@ import Button from '../Button';
 
     basically you're just going to pass the state you defined that will hold the boolean value to determine whether to show or hide modal.
 
-    e.g.       const [showModal, ] = useState()
+    e.g.       const [showModal, setShowModal] = useState()
 
                <Breadcrumbs showModal={showModal} setShowModal={setShowModal} />
 

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Card from 'react-bootstrap/Card';
-import Form from 'react-bootstrap/Form';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { VscFilter } from 'react-icons/vsc';
-import { BiSearch } from 'react-icons/bi';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
+import SearchBar from '../../../../components/SearchBar';
 import Pagination from '../../../../components/Pagination';
 import DataTable from '../../../../components/DataTable';
 import Button from '../../../../components/Button';
@@ -31,7 +30,6 @@ const AdminList = () => {
   const [totalItems, setTotalItems] = useState(0);
   const [lastPage, setLastPage] = useState(0);
   const [search, setSearch] = useState(searchVal ? searchVal : '');
-  const [searchStatus, setSearchStatus] = useState(false);
   const [sortOptions, setSortOptions] = useState({
     sortBy,
     sortDirection
@@ -50,7 +48,7 @@ const AdminList = () => {
     );
 
     load();
-  }, [page, searchStatus, sortOptions]);
+  }, [page, search, sortOptions]);
 
   useEffect(() => {
     if (deleteConfirmed) {
@@ -91,22 +89,6 @@ const AdminList = () => {
       );
   };
 
-  const onSearchSubmit = (e) => {
-    e.preventDefault();
-
-    setPage(1);
-    setSearchStatus(!searchStatus);
-  };
-
-  function onChangeData(e) {
-    setSearch(e.target.value);
-
-    if (e.target.value.length === 0) {
-      setPage(1);
-      setSearchStatus(!searchStatus);
-    }
-  }
-
   const onPageChange = (selected) => {
     setPage(selected + 1);
   };
@@ -116,7 +98,7 @@ const AdminList = () => {
       return (
         <tr key={idx} className={style.tableDataRow}>
           <td className={style.tableData}>{admin.id}</td>
-          <td className={`${style.tableData}`}>
+          <td className={style.tableData}>
             <Button
               buttonLabel="Delete"
               buttonSize="sm"
@@ -142,7 +124,7 @@ const AdminList = () => {
         itemToDelete={itemToDelete.name}
         setDeleteConfirmed={setDeleteConfirmed}
       />
-      <div className={style.headerTittleStyle}>
+      <div className={style.header}>
         <h1 className={style.pageTitle}>Admin Accounts</h1>
         <Link to="/admin/create-admin-account">
           <Button buttonLabel="Add an Admin" buttonSize="def" />
@@ -150,25 +132,11 @@ const AdminList = () => {
       </div>
       <Card className={style.card}>
         <Card.Header className={style.cardHeader}>
-          <Form className={style.searchSection} onSubmit={onSearchSubmit}>
-            <div className={style.searchInput}>
-              <Form.Control
-                className={style.searchBar}
-                type="text"
-                aria-label="Search"
-                value={search}
-                onChange={onChangeData}
-                placeholder="Search name or email"
-              />
-              <BiSearch size={17} className={style.searchIcon} />
-            </div>
-            <Button
-              className={style.searchButton}
-              buttonSize="sm"
-              buttonLabel="Search"
-              type="submit"
-            />
-          </Form>
+          <SearchBar
+            placeholder="Search by name or email"
+            search={search}
+            setSearch={setSearch}
+          />
           <Dropdown>
             <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
               Filter

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -65,7 +65,7 @@ const AdminList = () => {
         .catch(() =>
           toast(
             'Error',
-            'There was an error encountered while deleting the quiz.'
+            'There was an error encountered while deleting the admin user.'
           )
         );
     }

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -33,10 +33,10 @@
   padding-top: 2px;
 }
 
-.headerTittleStyle{
-  display: flex;
-  justify-content: space-between;
+.header {
   padding-top: 10px;
+
+  @include flex(space-between, center, row, none);
 }
 
 .card {
@@ -51,33 +51,6 @@
   box-shadow: $drop-shadow;
 
   @include flex(space-between, none, row, 0px);
-}
-
-.searchSection {
-  @include flex(none, center, row, 10px);
-}
-
-.searchInput {
-  position: relative;
-}
-
-.searchBar {
-  width: 335px;
-  padding-right: 34px;
-}
-
-.searchIcon {
-  position: absolute;
-  left: 92%;
-  top: 28%;
-}
-
-.searchButton {
-  @include button-style($color-light-blue-2, 93px, 38px);
-
-  &:hover {
-    background-color: $color-light-blue-3;
-  }
 }
 
 .dropdownButton {
@@ -123,7 +96,6 @@
   &:nth-child(3) {
     width: 432px;
   }
-
 }
 
 .tableDataRow {


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-328

### Definition of Done
* [x] Confirmation modal will appear when clicking the delete button
* [x] Entry will only delete after clicking the confirmation button
* [x] Reusable modal is created
* [x] Modal follows the design in Figma

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/80

### Notes
#### Pages Affected
- Quiz List Page: http://localhost:3003/admin/quizzes
- Admin List Page: http://localhost:3003/admin/users

### Scenarios/ Test Cases
* [x] Confirmation modal will appear when clicking the delete button
* [x] Entry will only delete after clicking the confirmation button
* [x] Reusable modal is created
* [x] Modal follows the design in Figma

### Screenshots
> ![DELETE QUIZ AND ADMIN](https://user-images.githubusercontent.com/91049234/158571978-8d292361-099f-498c-b7b9-8087b865a89d.gif)
