### PR TITLE
E_CLASSROOM-338 [Admin] [FE] Apply reusable components to table list pages

### DIFF
--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import Form from 'react-bootstrap/Form';
 import Button from '../../components/Button';
+import InputField from '../../components/InputField';
 import { BiSearch } from 'react-icons/bi';
 
 import style from './index.module.scss';
@@ -36,16 +37,16 @@ const SearchBar = ({ placeholder, search, setSearch }) => {
   return (
     <Form className={style.searchSection} onSubmit={onSearchSubmit}>
       <div className={style.searchInput}>
-        <Form.Control
-          className={style.searchBar}
+        <InputField
           type="text"
           value={searchValue}
+          fieldSize="lg"
           placeholder={placeholder}
           onChange={onSearchValueChange}
         />
         <BiSearch size={17} className={style.searchIcon} />
       </div>
-      <Button buttonLabel="Search" buttonSize="sm" type="submit"/>
+      <Button buttonLabel="Search" buttonSize="sm" type="submit" />
     </Form>
   );
 };

--- a/src/components/SearchBar/index.module.scss
+++ b/src/components/SearchBar/index.module.scss
@@ -10,14 +10,9 @@
   position: relative;
 }
 
-.searchBar {
-  width: 304px;
-  padding-right: 34px;
-}
-
 .searchIcon {
   position: absolute;
-  left: 92%;
+  left: 93%;
   top: 28%;
 }
 

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -2,9 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
 import Card from 'react-bootstrap/Card';
-import Dropdown from 'react-bootstrap/Dropdown';
-import { VscFilter } from 'react-icons/vsc';
 import ConfirmationModal from '../../../../components/ConfirmationModal';
+import FilterDropdown from '../../../../components/FilterDropdown';
 import SearchBar from '../../../../components/SearchBar';
 import Pagination from '../../../../components/Pagination';
 import DataTable from '../../../../components/DataTable';
@@ -137,12 +136,7 @@ const AdminList = () => {
             search={search}
             setSearch={setSearch}
           />
-          <Dropdown>
-            <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
-              Filter
-              <VscFilter size={17} />
-            </Dropdown.Toggle>
-          </Dropdown>
+          <FilterDropdown dropdownLabel="Filter" />
         </Card.Header>
         <Card.Body className={style.cardBody}>
           <DataTable

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -17,6 +17,7 @@ const AdminList = () => {
   const sortBy = queryParams.get('sortBy') || '';
   const searchVal = queryParams.get('search');
   const sortDirection = queryParams.get('sortDirection') || '';
+
   const history = useHistory();
   const toast = useToast();
 
@@ -150,7 +151,7 @@ const AdminList = () => {
         </Card.Body>
       </Card>
       <section>
-        <div id={style.pagPosition}>
+        <div id={style.pagination}>
           <Pagination
             page={page}
             perPage={perPage}

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -53,16 +53,6 @@
   @include flex(space-between, none, row, 0px);
 }
 
-.dropdownButton {
-  @include flex(center, center, row, 10px);
-  @include button-style($color-white, 93px, 38px);
-
-  &:hover {
-    background-color: $color-white;
-    color: $color-dark-blue-1;
-  }
-}
-
 .cardBody {
   padding: 0px 30px 30px 30px;
   overflow: auto;

--- a/src/pages/admin/Admin/AdminList/index.module.scss
+++ b/src/pages/admin/Admin/AdminList/index.module.scss
@@ -103,6 +103,6 @@
   }
 }
 
-#pagPosition {
+#pagination {
   float: right;
 }

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
+import { useToast } from '../../../../hooks/useToast';
 import Card from 'react-bootstrap/Card';
 import FilterDropdown from '../../../../components/FilterDropdown';
 import DataTable from '../../../../components/DataTable';
@@ -10,26 +11,32 @@ import CategoryApi from '../../../../api/Category';
 import style from './index.module.scss';
 
 const CategoryList = () => {
-  const [categories, setCategories] = useState(null);
   const queryParams = new URLSearchParams(window.location.search);
   const pageNum = queryParams.get('page');
   const searchVal = queryParams.get('search');
   const sortBy = queryParams.get('sortBy') || '';
   const sortDirection = queryParams.get('sortDirection') || '';
 
-  const [search, setSearch] = useState(searchVal ? searchVal : '');
-
   const history = useHistory();
+  const toast = useToast();
 
+  const [categories, setCategories] = useState(null);
+  const [search, setSearch] = useState(searchVal ? searchVal : '');
   const [page, setPage] = useState(pageNum ? parseInt(pageNum) : 1);
   const [perPage, setPerPage] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
   const [lastPage, setLastPage] = useState(0);
-
   const [sortOptions, setSortOptions] = useState({
     sortBy,
     sortDirection
   });
+
+  const tableHeaderNames = [
+    { title: 'ID', canSort: true },
+    { title: 'Action', canSort: false },
+    { title: 'Name', canSort: true },
+    { title: 'Description', canSort: false }
+  ];
 
   useEffect(() => {
     setCategories(null);
@@ -44,31 +51,28 @@ const CategoryList = () => {
       sortBy: sortOptions.sortBy,
       sortDirection: sortOptions.sortDirection,
       listCondition: 'paginated'
-    }).then(({ data }) => {
-      setCategories(data.data);
-      setPerPage(data.per_page);
-      setTotalItems(data.total);
-      setLastPage(data.last_page);
-    });
+    })
+      .then(({ data }) => {
+        setCategories(data.data);
+        setPerPage(data.per_page);
+        setTotalItems(data.total);
+        setLastPage(data.last_page);
+      })
+      .catch(() =>
+        toast('Error', 'There was an error getting the list of categories.')
+      );
   }, [page, search, sortOptions]);
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
   };
 
-  const tableHeaderNames = [
-    { title: 'ID', canSort: true },
-    { title: 'Action', canSort: false },
-    { title: 'Name', canSort: true },
-    { title: 'Description', canSort: false }
-  ];
-
   const renderTableData = () => {
     return categories?.map((category, idx) => {
       return (
         <tr key={idx}>
-          <td id={style.tBodyStyle}>{category.id}</td>
-          <td id={style.tBodyStyle1}>
+          <td id={style.tableData}>{category.id}</td>
+          <td id={style.actionButtonsColumn}>
             <td>
               <Link to={`/admin/edit-category/${category.id}`}>
                 <Button buttonLabel="Edit" buttonSize="sm" />
@@ -78,8 +82,8 @@ const CategoryList = () => {
               <Button buttonLabel="Delete" buttonSize="sm" outline={true} />
             </td>
           </td>
-          <td id={style.tBodyStyle}>{category.name}</td>
-          <td id={style.tBodyStyle} className={`${style.paragraphEllipsis}`}>
+          <td id={style.tableData}>{category.name}</td>
+          <td id={style.tableData} className={`${style.paragraphEllipsis}`}>
             {category.description}
           </td>
         </tr>
@@ -90,7 +94,7 @@ const CategoryList = () => {
   return (
     <div className={style.cardContainer}>
       <div>
-        <div className={style.headerTitle}>
+        <div className={style.header}>
           <p className={style.title}>Categories</p>
           <Link to="/admin/add-category" className={style.addButton}>
             <Button buttonLabel="Add Category" buttonSize="def" />
@@ -110,7 +114,7 @@ const CategoryList = () => {
               <DataTable
                 tableHeaderNames={tableHeaderNames}
                 renderTableData={renderTableData}
-                titleHeaderStyle={style.classCol}
+                titleHeaderStyle={style.tableHeader}
                 sortOptions={sortOptions}
                 setSortOptions={setSortOptions}
                 data={categories}
@@ -119,7 +123,7 @@ const CategoryList = () => {
           </Card.Body>
         </Card>
         <div className="pt-4">
-          <div id={style.paginateStyle}>
+          <div id={style.pagination}>
             <Pagination
               page={page}
               perPage={perPage}

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import Card from 'react-bootstrap/Card';
-import Dropdown from 'react-bootstrap/Dropdown';
-import Pagination from '../../../../components/Pagination';
-import { VscFilter } from 'react-icons/vsc';
-import Button from '../../../../components/Button';
-
-import style from './index.module.scss';
-
-import CategoryApi from '../../../../api/Category';
+import FilterDropdown from '../../../../components/FilterDropdown';
 import DataTable from '../../../../components/DataTable';
 import SearchBar from '../../../../components/SearchBar';
+import Pagination from '../../../../components/Pagination';
+import Button from '../../../../components/Button';
+import CategoryApi from '../../../../api/Category';
+import style from './index.module.scss';
 
 const CategoryList = () => {
   const [categories, setCategories] = useState(null);
@@ -63,7 +60,7 @@ const CategoryList = () => {
     { title: 'ID', canSort: true },
     { title: 'Action', canSort: false },
     { title: 'Name', canSort: true },
-    { title: 'Description', canSort: false },
+    { title: 'Description', canSort: false }
   ];
 
   const renderTableData = () => {
@@ -74,11 +71,11 @@ const CategoryList = () => {
           <td id={style.tBodyStyle1}>
             <td>
               <Link to={`/admin/edit-category/${category.id}`}>
-                <Button buttonLabel="Edit" buttonSize="sm"/>
+                <Button buttonLabel="Edit" buttonSize="sm" />
               </Link>
             </td>
             <td>
-              <Button buttonLabel="Delete" buttonSize="sm" outline={true}/>
+              <Button buttonLabel="Delete" buttonSize="sm" outline={true} />
             </td>
           </td>
           <td id={style.tBodyStyle}>{category.name}</td>
@@ -96,7 +93,7 @@ const CategoryList = () => {
         <div className={style.headerTitle}>
           <p className={style.title}>Categories</p>
           <Link to="/admin/add-category" className={style.addButton}>
-            <Button buttonLabel="Add Category" buttonSize="def"/>
+            <Button buttonLabel="Add Category" buttonSize="def" />
           </Link>
         </div>
         <Card className={style.mainCard}>
@@ -106,12 +103,7 @@ const CategoryList = () => {
               search={search}
               setSearch={setSearch}
             />
-            <Dropdown>
-              <Dropdown.Toggle className={style.dropdownButton} bsPrefix="none">
-                Filter
-                <VscFilter size={17} />
-              </Dropdown.Toggle>
-            </Dropdown>
+            <FilterDropdown dropdownLabel="Filter" />
           </Card.Header>
           <Card.Body className={style.cardBodyScroll}>
             <div>

--- a/src/pages/admin/categories/CategoryList/index.module.scss
+++ b/src/pages/admin/categories/CategoryList/index.module.scss
@@ -2,15 +2,6 @@
 
 @use '../../../../styles/global-styles' as *;
 
-@mixin button-style($background-color, $width, $height) {
-  background-color: $background-color;
-  color: $color-dark-blue-1;
-  font-size: $font-size-md;
-  border: none;
-  height: $height;
-  width: $width;
-}
-
 @mixin flex($justify-value, $align-value, $direction, $gap-value) {
   display: flex;
   align-items: $align-value;
@@ -38,46 +29,22 @@
 
 .cardHeader {
   height: auto;
-  background-color: $color-light-blue-1;
   padding: 12px 20px;
   box-shadow: $drop-shadow;
+  background-color: $color-light-blue-1;
 
   @include flex(space-between, none, row, 0px);
 }
 
-.searchSection {
-  @include flex(none, center, row, 10px);
-}
-
-.searchInput {
-  position: relative;
-}
-
-.searchBar {
-  width: 335px;
-  padding-right: 34px;
-}
-
-.searchIcon {
-  position: absolute;
-  left: 92%;
-  top: 28%;
-}
-
-.searchButton {
-  @include button-style($color-light-blue-2, 93px, 38px);
-
-  &:hover {
-    background-color: $color-light-blue-3;
-    color: $color-white;
-  }
+.header {
+  @include flex(space-between, center, row, 0px);
 }
 
 .title {
+  margin: 0px;
   padding: 0px 0px 23px;
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title;
-  margin: 0px;
 }
 
 .addButton {
@@ -90,13 +57,13 @@
   padding: 0px 30px 30px 30px;
 }
 
-#tBodyStyle {
+#tableData {
   @extend %style-table-body;
   color: $color-dark-blue-1;
 
   &:nth-child(3) {
-    padding-right: 88px;
     height: 74px;
+    padding-right: 88px;
     padding-left: 60px;
   }
 
@@ -106,14 +73,13 @@
   }
 }
 
-#tBodyStyle1 {
-  @extend %style-table-body;
-  align-items: center;
-  display: flex;
-  padding-top: 10px;
-  gap: 11px;
+#actionButtonsColumn {
   width: 0px;
+  padding-top: 10px;
   margin-left: 60px;
+
+  @extend %style-table-body;
+  @include flex(none, center, row, 11px);
 }
 
 .firstCol {
@@ -132,17 +98,11 @@
   }
 }
 
-.firstCol1 {
-  @extend %style-table-head;
-  text-align: center;
-  width: 88px;
-}
-
-#paginateStyle {
+#pagination {
   float: right;
 }
 
-.classCol {
+.tableHeader {
   @extend %style-table-head;
 
   &:nth-child(1) {
@@ -164,10 +124,4 @@
     width: 210px;
     padding-left: 50px;
   }
-}
-
-.headerTitle {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }

--- a/src/pages/admin/categories/CategoryList/index.module.scss
+++ b/src/pages/admin/categories/CategoryList/index.module.scss
@@ -73,16 +73,6 @@
   }
 }
 
-.dropdownButton {
-  @include flex(center, center, row, 10px);
-  @include button-style($color-white, 93px, 38px);
-
-  &:hover {
-    background-color: $color-white;
-    color: $color-dark-blue-1;
-  }
-}
-
 .title {
   padding: 0px 0px 23px;
   font-weight: $font-weight-medium;
@@ -107,12 +97,12 @@
   &:nth-child(3) {
     padding-right: 88px;
     height: 74px;
-    padding-left: 60px
+    padding-left: 60px;
   }
 
   &:nth-child(4) {
     height: 74px;
-    padding-left: 50px
+    padding-left: 50px;
   }
 }
 
@@ -167,14 +157,13 @@
 
   &:nth-child(3) {
     width: 250px;
-    padding-left: 60px
+    padding-left: 60px;
   }
 
   &:nth-child(4) {
     width: 210px;
-    padding-left: 50px
+    padding-left: 50px;
   }
-
 }
 
 .headerTitle {

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -147,7 +147,7 @@ const QuizList = () => {
     return adminQuiz?.map((quiz, idx) => {
       return (
         <tr key={idx}>
-          <td id={style.classColumn}>{quiz.id}</td>
+          <td id={style.tableData}>{quiz.id}</td>
           <td id={style.buttonColumn}>
             <center>
               <Link to={`/admin/quizzes/${quiz.id}`}>
@@ -166,8 +166,8 @@ const QuizList = () => {
               />
             </center>
           </td>
-          <td id={style.classColumn}>{quiz.name}</td>
-          <td id={style.classColumn}>{quiz.title}</td>
+          <td id={style.tableData}>{quiz.name}</td>
+          <td id={style.tableData}>{quiz.title}</td>
         </tr>
       );
     });
@@ -182,7 +182,7 @@ const QuizList = () => {
         setDeleteConfirmed={setDeleteConfirmed}
       />
       <div>
-        <div className={style.headerTittleStyle}>
+        <div className={style.header}>
           <p className={style.title}>Quizzes</p>
           <Button
             buttonStyle={style.addButton}
@@ -212,7 +212,7 @@ const QuizList = () => {
                 <DataTable
                   tableHeaderNames={tableHeaderNames}
                   renderTableData={renderTableData}
-                  titleHeaderStyle={style.classCol}
+                  titleHeaderStyle={style.tableHeader}
                   sortOptions={sortOptions}
                   setSortOptions={setSortOptions}
                   data={adminQuiz}
@@ -223,7 +223,7 @@ const QuizList = () => {
         </Col>
       </div>
       <div className="pt-4">
-        <div id={style.paginateStyle}>
+        <div id={style.pagination}>
           <Pagination
             page={page}
             perPage={perPage}

--- a/src/pages/admin/quizzes/QuizList/index.module.scss
+++ b/src/pages/admin/quizzes/QuizList/index.module.scss
@@ -53,7 +53,7 @@
   padding: 12px 20px;
   box-shadow: $drop-shadow;
 
-  @include flex(space-between, none, row, 0px);
+  @include flex(space-between, center, row, 0px);
 }
 
 .title {
@@ -62,10 +62,10 @@
   margin: 0px;
 }
 
-.headerTittleStyle{
-  display: flex;
-  justify-content: space-between;
+.header {
   padding-top: 10px;
+
+  @include flex(space-between, center, row, 0px);
 }
 
 .addButton {
@@ -94,31 +94,30 @@
   padding: 0px 30px 30px 30px;
 }
 
-#classColumn {
+#tableData {
   @extend %style-table-body;
   color: $color-dark-blue-1;
 
   &:nth-child(3) {
     height: 74px;
-    padding-left: 60px
+    padding-left: 60px;
   }
 
   &:nth-child(4) {
-    padding-left: 50px
+    padding-left: 50px;
   }
 }
 
 #buttonColumn {
-  @extend %style-table-body;
-  align-items: center;
-  display: flex;
-  padding-top: 10px;
-  gap: 11px;
   width: 0px;
+  padding-top: 10px;
   margin-left: 60px;
+
+  @extend %style-table-body;
+  @include flex(none, center, row, 11px);
 }
 
-#paginateStyle {
+#pagination {
   float: right;
 }
 
@@ -198,7 +197,7 @@
   color: $color-dark-blue-1;
 }
 
-.classCol {
+.tableHeader {
   @extend %style-table-head;
 
   &:nth-child(1) {
@@ -213,11 +212,11 @@
 
   &:nth-child(3) {
     width: 250px;
-    padding-left: 60px
+    padding-left: 60px;
   }
 
   &:nth-child(4) {
     width: 210px;
-    padding-left: 50px
+    padding-left: 50px;
   }
 }


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-338

### Definition of Done
- [x] Reusable components are applied in all pages (Categories, Quizzes, and Admins List Pages)
- [x] Layout is not broken
- [x] Everything is still functioning correctly

### Notes
#### Main note
- The only component that was not reusable was the dropdown button and the search input field in the Categories and Admins List Page

#### Pages Affected
- Categories List Page: http://localhost:3003/admin/categories
- Quizzes List Page: http://localhost:3003/admin/quizzes
- Admins List Page: http://localhost:3003/admin/users

### Scenarios/ Test Cases
- [x] Reusable components are applied in all pages (Categories, Quizzes, and Admins List Pages)
- [x] Layout is not broken
- [x] Everything is still functioning correctly

### Screenshots
Categories List Page
>![image](https://user-images.githubusercontent.com/91049234/159199982-071d9c2f-9166-437f-86e5-d56a40606713.png)

Quizzes List Page
> ![image](https://user-images.githubusercontent.com/91049234/159200047-a7d4a10e-e7f4-46e7-9818-ad597505d2f2.png)

Admins List Page
> ![image](https://user-images.githubusercontent.com/91049234/159200089-f6b05284-cb9f-4217-8a73-94828938e377.png)
