### PR TITLE
E_CLASSROOM-343 [Bugfix] User can input admin email in student forget password

### DIFF
--- a/src/pages/student/main/PasswordReset/index.js
+++ b/src/pages/student/main/PasswordReset/index.js
@@ -35,7 +35,7 @@ const PasswordReset = () => {
         setEmailSent(true);
       })
       .catch((error) => {
-        toast('Error', 'Incorrect email address, please try again.');
+        toast('Error', error.response.data.error);
         setError(error.response.data.error);
         setSubmitStatus(false);
       });
@@ -47,8 +47,8 @@ const PasswordReset = () => {
         <Form onSubmit={handleSubmit(handleOnSubmit)}>
           {!emailSent ? (
             <div className={style.formContainer}>
-              <Form.Label className={style.headerStyle}> 
-                Password Reset 
+              <Form.Label className={style.headerStyle}>
+                Password Reset
               </Form.Label>
               <Form.Group className="mb-3" controlId="Email">
                 <Form.Label>


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-343

### Definition of Done
- [x] An admin user should not be able to reset their password in the forget password page of the student route

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/85

### Notes
#### Pages Affected
- Forgot Password Page: http://localhost:3003/reset-password

### Scenarios/ Test Cases
- [x] An admin user should not be able to reset their password in the forget password page of the student route
- [x] It should show an error indicating that the user is not authorized to access the page.

### Screenshots
> ![FORGOT PASSWORD](https://user-images.githubusercontent.com/91049234/159625319-bffbb799-b20e-46f1-bb17-efaedfea8fbd.gif)
