### PR TITLE
E_CLASSROOM-345 [Bugfix] User name in admin sidebar is not dynamic

### DIFF
--- a/src/components/NavigationSideBar/index.js
+++ b/src/components/NavigationSideBar/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useToast } from '../../hooks/useToast';
 import Navbar from 'react-bootstrap/Navbar';
 import { Nav, Container } from 'react-bootstrap';
@@ -8,12 +8,21 @@ import { BiCategory, BiLogOutCircle, BiShieldQuarter } from 'react-icons/bi';
 import { BsCardChecklist } from 'react-icons/bs';
 import { IoIosPeople } from 'react-icons/io';
 import Cookies from 'js-cookie';
+import AdminApi from '../../api/Admin';
 
 import style from './index.module.css';
 import AuthApi from '../../api/Auth';
 
 const NavigationSideBar = () => {
   const toast = useToast();
+  const [profileName, setprofileName] = useState(null);
+  const loggedInUserId = Cookies.get('admin_id');
+
+  useEffect(() => {
+    AdminApi.getAllUsers(loggedInUserId).then(({ data }) => {
+      setprofileName(data[0]);
+    });
+  }, []);
 
   const onLogout = async () => {
     toast('Processing', 'Logging out...');
@@ -41,7 +50,7 @@ const NavigationSideBar = () => {
               alt="Profile Icon"
             />
           </div>
-          <p className={style.username}>John Doe</p>
+          <p className={style.username}>{profileName?.name}</p>
           <p className={style.userRole}>Admin</p>
         </div>
       </div>


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-345
### Definition of Done
- [X] Make the user name in the admin sidebar reflect the currently logged in user

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/admin/categories

### Scenarios/ Test Cases
- [ ] Make the user name in the admin sidebar reflect the currently logged in user
#### User Interface
N/A
#### User Experience 
N/A
#### Functionality
N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89382909/159648302-15040ef0-10a7-4883-a122-b7f0e2d2f803.png)
