### PR TITLE
E_CLASSROOM-346 [Bugfix] Choices from previous question appears on click of next question

### DIFF
--- a/src/pages/admin/quizzes/QuizEdit/components/IdentificationType/index.js
+++ b/src/pages/admin/quizzes/QuizEdit/components/IdentificationType/index.js
@@ -1,16 +1,18 @@
 import React, { Fragment, useState, useEffect } from 'react';
-import Form from 'react-bootstrap/Form';
-import style from '../../index.module.scss';
-import { PropTypes } from 'prop-types';
 import { Controller, useForm } from 'react-hook-form';
+import { PropTypes } from 'prop-types';
+import Form from 'react-bootstrap/Form';
 import InputField from '../../../../../../components/InputField';
+
+import style from '../../index.module.scss';
 
 const IdentificationType = ({ question, getData }) => {
   const { control } = useForm();
-  const [questionOnChange, setQuestionOnChange ] = useState({
-    question : question.question,
+  const [questionUpdated, setQuestionUpdated] = useState(false);
+  const [questionOnChange, setQuestionOnChange] = useState({
+    question: question.question,
     answer: question.text_answer,
-    questionId: question.id,
+    questionId: question.id
   });
 
   useEffect(() => {
@@ -27,22 +29,24 @@ const IdentificationType = ({ question, getData }) => {
       ...questionOnChange,
       question: e.target.value
     });
+    setQuestionUpdated(true);
   };
-  
+
   useEffect(() => {
-    if(questionOnChange){
+    if (questionUpdated) {
       getData(questionOnChange);
+      setQuestionUpdated(false);
     }
-  }, [questionOnChange]);
+  }, [questionUpdated]);
 
   const handleChangeAnswer = (e) => {
     setQuestionOnChange({
       ...questionOnChange,
       answer: e.target.value
     });
-    getData(questionOnChange);
+    setQuestionUpdated(true);
   };
-  
+
   return (
     <Fragment>
       <div>
@@ -56,7 +60,7 @@ const IdentificationType = ({ question, getData }) => {
               <InputField
                 type="text"
                 inputStyle={style.inputWidth}
-                onChange ={handleChangeQuestion}
+                onChange={handleChangeQuestion}
                 value={questionOnChange.question}
                 ref={ref}
               />
@@ -71,10 +75,10 @@ const IdentificationType = ({ question, getData }) => {
           name="text_answer"
           defaultValue={question.text_answer}
           render={({ field: { ref } }) => (
-            <InputField 
-              as="textarea" 
-              inputStyle={style.inputHeight} 
-              onChange ={handleChangeAnswer}
+            <InputField
+              as="textarea"
+              inputStyle={style.inputHeight}
+              onChange={handleChangeAnswer}
               value={questionOnChange.answer}
               ref={ref}
             />
@@ -87,7 +91,7 @@ const IdentificationType = ({ question, getData }) => {
 
 IdentificationType.propTypes = {
   question: PropTypes.object,
-  getData: PropTypes.func,
+  getData: PropTypes.func
 };
 
 export default IdentificationType;

--- a/src/pages/admin/quizzes/QuizEdit/components/QuestionType/index.js
+++ b/src/pages/admin/quizzes/QuizEdit/components/QuestionType/index.js
@@ -1,27 +1,40 @@
 import React, { useState, Fragment, useEffect } from 'react';
+import { PropTypes } from 'prop-types';
 import Form from 'react-bootstrap/Form';
+
+import FilterDropdown from '../../../../../../components/FilterDropdown';
 import MultipleChoiceType from '../MultipleChoiceType';
 import IdentificationType from '../IdentificationType';
-import PropTypes from 'prop-types';
 
 import style from '../../index.module.scss';
-import FilterDropdown from '../../../../../../components/FilterDropdown';
 
-const QuestionType = ({ question, onGetData, onChangeTimeLimit, onChangeQuestionType, onChangeChoices }) => {
+const QuestionType = ({
+  question,
+  onGetData,
+  onChangeTimeLimit,
+  onChangeQuestionType,
+  onChangeChoices
+}) => {
   const [questionType, setQuestionType] = useState('multiple_choice');
   const [timeLimit, setTimeLimit] = useState(0);
-  const timeOptions = [{name: 5}, {name: 10}, {name: 20}, {name: 30}, {name: 60}];
+  const timeOptions = [
+    { name: 5 },
+    { name: 10 },
+    { name: 20 },
+    { name: 30 },
+    { name: 60 }
+  ];
   const question_type_id = [
     {
       name: 'Multiple Choice',
-      value: '1',
+      value: '1'
     },
     {
       name: 'Identification',
-      value: '2',
-    },
+      value: '2'
+    }
   ];
-  
+
   useEffect(() => {
     if (question) {
       setQuestionType(question?.question_type_id?.toString());
@@ -40,7 +53,7 @@ const QuestionType = ({ question, onGetData, onChangeTimeLimit, onChangeQuestion
   // Watches changes in the questionType variable
   // If questionType is changed, call function and pass new questionType value and question id
   useEffect(() => {
-    if (question){
+    if (question) {
       onChangeQuestionType(questionType, question.id);
     }
   }, [questionType]);
@@ -62,11 +75,22 @@ const QuestionType = ({ question, onGetData, onChangeTimeLimit, onChangeQuestion
   };
 
   const question_type = (choice) => {
-    switch (choice) {  
+    switch (choice) {
     case '1':
-      return <MultipleChoiceType question={question} getData={handleChangeQuestionType} onUpdateChoices={updateChoices}/>;
+      return (
+        <MultipleChoiceType
+          question={question}
+          getData={handleChangeQuestionType}
+          onUpdateChoices={updateChoices}
+        />
+      );
     case '2':
-      return <IdentificationType question={question} getData = {handleChangeQuestionType} />;
+      return (
+        <IdentificationType
+          question={question}
+          getData={handleChangeQuestionType}
+        />
+      );
     default:
       break;
     }
@@ -89,7 +113,9 @@ const QuestionType = ({ question, onGetData, onChangeTimeLimit, onChangeQuestion
 
   return (
     <Fragment>
-      <div  className={style.questionTypestyle}>{question_type(questionType)}</div>
+      <div className={style.questionTypestyle}>
+        {question_type(questionType)}
+      </div>
       <div className={style.formGap}>
         <Form>
           <Form.Label className={style.inputTitle}>Question Type</Form.Label>

--- a/src/pages/admin/quizzes/QuizEdit/index.js
+++ b/src/pages/admin/quizzes/QuizEdit/index.js
@@ -1,12 +1,11 @@
 import React, { Fragment, useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
-import Button from '../../../../components/Button';
 import Nav from 'react-bootstrap/Nav';
 import Spinner from 'react-bootstrap/Spinner';
 import { AiOutlineCloseCircle } from 'react-icons/ai';
 
-import style from './index.module.scss';
+import Button from '../../../../components/Button';
 import QuestionType from './components/QuestionType';
 import ChangeLocation from '../../../../components/ChangeLocation';
 
@@ -14,22 +13,26 @@ import QuizApi from '../../../../api/Quiz';
 import QuestionApi from '../../../../api/Question';
 import CategoryApi from '../../../../api/Category';
 
+import style from './index.module.scss';
+
 const QuizEdit = () => {
+  const { categoryId, quizId } = useParams();
   const TYPE = 'quizWithPathDisplay';
-  const [locationPathDisplay, setLocationPathDisplay] = useState('');
-  const [location, setLocation] = useState(null);
-  const [quizInfo, setQuizInfo] = useState(null);
-  const [questions, setQuestions] = useState(null);
+  const toast = useToast();
+
   const [selectedQuestion, setSelectedQuestion] = useState(null);
   const [changeCategoryId, setChangeCategoryId] = useState(null);
   const [parentCategories, setParentCategories] = useState(null);
+  const [locationPathDisplay, setLocationPathDisplay] = useState('');
   const [saveLocation, setSaveLocation] = useState(false);
+  const [questions, setQuestions] = useState(null);
+  const [location, setLocation] = useState(null);
+  const [quizInfo, setQuizInfo] = useState(null);
+  const [saved, setSaved] = useState(false);
   const [show, setShow] = useState(false);
+
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
-  const { categoryId, quizId } = useParams();
-  const [saved, setSaved] = useState(false);
-  const toast = useToast();
 
   useEffect(() => {
     QuizApi.show({ categoryId, quizId }).then(({ data }) => {

--- a/src/pages/admin/quizzes/QuizEdit/index.js
+++ b/src/pages/admin/quizzes/QuizEdit/index.js
@@ -28,6 +28,7 @@ const QuizEdit = () => {
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
   const { categoryId, quizId } = useParams();
+  const [saved, setSaved] = useState(false);
   const toast = useToast();
 
   useEffect(() => {
@@ -42,7 +43,7 @@ const QuizEdit = () => {
   }, []);
 
   useEffect(() => {
-    if(quizInfo){
+    if (quizInfo) {
       setChangeCategoryId(quizInfo.category_id);
       CategoryApi.getParentCategories(quizInfo.category_id)
         .then(({ data }) => {
@@ -130,7 +131,10 @@ const QuizEdit = () => {
   };
 
   const addQuestionFields = () => {
-    const questionIds = questions && questions.length > 0 ? questions.map((question) => question.id) : [0];
+    const questionIds =
+      questions && questions.length > 0
+        ? questions.map((question) => question.id)
+        : [0];
     const maxId = Math.max(...questionIds) + 1;
     let newQuestions = [...questions];
     newQuestions.push({
@@ -151,7 +155,7 @@ const QuizEdit = () => {
     newQuestions.splice(idx, 1);
     setQuestions(newQuestions);
 
-    if(idx < newQuestions.length){
+    if (idx < newQuestions.length) {
       setSelectedQuestion(newQuestions[idx]);
     } else {
       setSelectedQuestion(newQuestions[idx - 1]);
@@ -160,9 +164,11 @@ const QuizEdit = () => {
 
   const handleSubmit = () => {
     toast('Processing', 'Updating questions...');
+    setSaved(true);
 
     QuestionApi.editQuestion(questions, quizId, changeCategoryId)
       .then(({ data }) => {
+        setSaved(false);
         setQuestions(data);
         toast('Success', 'Successfully updated questions');
         window.location = `/admin/quizzes/${quizId}`;
@@ -192,10 +198,17 @@ const QuizEdit = () => {
                       <Nav className="flex-column">
                         <Nav.Link
                           eventKey={question.id}
-                          className={selectedQuestion?.id === question.id ? style.currentNavLinkItem : style.navLinkItem}
+                          className={
+                            selectedQuestion?.id === question.id
+                              ? style.currentNavLinkItem
+                              : style.navLinkItem
+                          }
                           active
                         >
-                          <div className={style.questionDetails} onClick={() => onSelectQuestion(idx)}>
+                          <div
+                            className={style.questionDetails}
+                            onClick={() => onSelectQuestion(idx)}
+                          >
                             <span className={style.questionNumber}>
                               Question # {idx + 1}
                             </span>
@@ -207,7 +220,7 @@ const QuizEdit = () => {
                             size={25}
                             className={style.removeQuestionIcon}
                             onClick={() => {
-                              onRemoveQuestion(idx); 
+                              onRemoveQuestion(idx);
                             }}
                           />
                         </Nav.Link>
@@ -215,8 +228,16 @@ const QuizEdit = () => {
                     </Fragment>
                   );
                 })}
-              <Button buttonLabel="Add a Question" buttonSize="lg"  onClick={() => addQuestionFields()}/>
-              <Button buttonLabel="Change Category" buttonSize="lg" onClick={handleShow}/>
+              <Button
+                buttonLabel="Add a Question"
+                buttonSize="lg"
+                onClick={() => addQuestionFields()}
+              />
+              <Button
+                buttonLabel="Change Category"
+                buttonSize="lg"
+                onClick={handleShow}
+              />
             </div>
             {questions?.length === 0 ? (
               <div className={style.message}>
@@ -237,7 +258,12 @@ const QuizEdit = () => {
           <Link to={`/admin/quizzes/${quizId}`} className={style.cancelButton}>
             Cancel
           </Link>
-          <Button buttonLabel="Save" buttonSize="def" onClick={handleSubmit}/>
+          <Button
+            buttonLabel="Save"
+            buttonSize="def"
+            onClick={handleSubmit}
+            disabled={saved}
+          />
         </div>
       </div>
       <ChangeLocation


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-346

### Definition of Done
- [x] When switching from one question to another, it should show the question's own choices instead of the choices from the first question.

### Notes
#### Main note
- To test if the bug fix works, please create a quiz with questions with the same type in sequence.
- Sample:
> 1. Multiple Choice Question
> 2. Multiple Choice Question
> 3. Identification Question
> 4. Identification Question
- When switching from the first question to the second question, the choices being displayed should be the choices of the clicked question and should not change unless it's being updated, the same goes for the identification type questions.

#### Pages Affected
- Quiz Overview Page: http://localhost:3003/admin/quizzes/<quiz_id>
- Click the Edit Button on that page to redirect to the Quiz Edit Page.

### Scenarios/ Test Cases
- [x] When switching from the first question to the second question, the choices being displayed should be the choices of the clicked question and should not change unless it's being updated, the same goes for the identification type questions.

### Screenshots
> ![QUIZ EDIT BUG](https://user-images.githubusercontent.com/91049234/159834857-d0159586-8d0d-4104-b847-12d637ac304b.gif)
