### PR TITLE
E_CLASSROOM-348 [Bugfix] Quiz title in /categories is not truncated

### DIFF
--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
@@ -72,17 +72,17 @@ const QuizzesCard = ({ category_id, quiz }) => {
         <Card.Body className={style.cardBody}>
           <div className={style.quizInfo}>
             <div className={style.quizResult}>
-              <p>Attempts</p>
+              <p className="mb-0">Attempts</p>
               <p>{QuizzesRecentReview?.length}</p>
             </div>
             <div className={style.quizResult}>
-              <p>Highest Score</p>
+              <p className="mb-0">Highest Score</p>
               <p>
                 {getHighestScore()}/{questions?.length}
               </p>
             </div>
             <div className={style.quizResult} style={{ fontWeight: 'bold' }}>
-              <p>Latest Score</p>
+              <p className="mb-0">Latest Score</p>
               <p>
                 {getLatestScore() >= 0 ? getLatestScore() : 0}/
                 {questions?.length}

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -34,14 +34,14 @@
 }
 
 .titleHeader {
-  font-weight: bold;
-  font-size: 18px;
+  font-weight: $font-weight-bold;
+  font-size: $font-size-lg;
   color: $color-dark-blue-1;
 }
 
 .clockHeader {
-  font-size: 12px;
-  color: #48535b;
+  font-size: $font-size-sm;
+  color: $color-dark-blue-1;
   margin-top: 5px;
 }
 
@@ -54,7 +54,7 @@
 .titleHeader {
   font-weight: $font-weight-medium;
   color: $color-dark-blue-1;
-  font-size: 18px;
+  font-size: $font-size-lg;
 
   display: -webkit-box;
   max-width: 295px;
@@ -83,11 +83,10 @@
 
 .quizLink {
   width: auto;
+  margin: 20px;
   display: flex;
   justify-content: flex-end;
-  margin: 20px;
-  font-weight: bold;
-
+  font-weight: $font-weight-bold;
   font-size: $font-size-base;
   color: $color-dark-blue-2;
 

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -7,7 +7,7 @@
 }
 
 .card {
-  width: 295px;
+  width: 400px;
 }
 
 .cardHeader {
@@ -17,15 +17,15 @@
   border-bottom-right-radius: 0px;
   filter: drop-shadow(0 1mm 1mm #48535b8c);
   margin-bottom: 4px;
-  padding: 10px 25px;
+  padding: 10px 20px;
 }
 
 .cardBody {
   color: $color-dark-blue-1;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
-  height: 140px;
-  padding-bottom: 0px;
+  height: 130px;
+  padding: 20px;
 }
 
 .cardTitle {
@@ -53,21 +53,29 @@
 
 .titleHeader {
   font-weight: $font-weight-medium;
-  font-size: 18px;
   color: $color-dark-blue-1;
+  font-size: 18px;
+
+  display: -webkit-box;
+  max-width: 295px;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .quizInfo {
-  padding: 10px 10px 0px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
   margin-bottom: 0px;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
-  width: 265px;
 }
 
 .quizResult {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 0px;
   font-size: $font-size-base;
   font-weight: $font-weight-light;
@@ -77,12 +85,11 @@
   width: auto;
   display: flex;
   justify-content: flex-end;
-  padding-right: 25px;
-  color: $color-dark-blue-2;
-  margin-bottom: 9px;
+  margin: 20px;
   font-weight: bold;
-  margin-top: 0px;
+
   font-size: $font-size-base;
+  color: $color-dark-blue-2;
 
   &:hover {
     color: $color-dark-blue-3;

--- a/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.scss
@@ -1,43 +1,41 @@
 @use '../../../../../../styles/variables' as *;
 
 #cardHeader {
-    background-color: $color-light-blue-1;
-    width: 298px;
-    height: 167px;
-    box-shadow: $drop-shadow;
-    position: relative;
-    z-index: 1;
-    padding: 15px;
-    font-size: $font-size-lg;
+  background-color: $color-light-blue-1;
+  box-shadow: $drop-shadow;
+  font-size: $font-size-lg;
+  position: relative;
+  height: 200px;
+  padding: 20px;
+  z-index: 1;
 }
 
 .card {
-    height: 217px;
-    width: 300px;
-    min-width: auto;
+  height: 217px;
+  width: 400px;
 }
 
-.cardTitle{
-    font-size: $font-size-lg;
-    font-weight: $font-weight-regular;
-    line-height: 21px;
+.cardTitle {
+  font-weight: $font-weight-regular;
+  font-size: $font-size-lg;
+  line-height: 21px;
 }
 
-.cardSubtitle{
-    font-size: 14px;
-    font-weight: 300;
-    line-height: 16px;
-    text-align: justify;
+.cardSubtitle {
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 16px;
+  text-align: justify;
 }
 
-#Subtitle{
-    font-size: 12px;
-    font-weight: $font-weight-regular;
-    color: $color-dark-blue-2;
+#Subtitle {
+  font-weight: $font-weight-regular;
+  color: $color-dark-blue-2;
+  font-size: 12px;
 }
 
 .containerCard {
-    flex: 0;
-    width: auto;
-    padding-right: 0;
+  flex: 0;
+  width: auto;
+  padding-right: 0;
 }

--- a/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/SubcategoryCard/index.module.scss
@@ -22,8 +22,8 @@
 }
 
 .cardSubtitle {
-  font-size: 14px;
-  font-weight: 300;
+  font-size: $font-size-md;
+  font-weight: $font-weight-light;
   line-height: 16px;
   text-align: justify;
 }
@@ -31,7 +31,7 @@
 #Subtitle {
   font-weight: $font-weight-regular;
   color: $color-dark-blue-2;
-  font-size: 12px;
+  font-size: $font-size-sm;
 }
 
 .containerCard {

--- a/src/pages/student/categories/CategoryDetail/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/index.module.scss
@@ -14,15 +14,17 @@
   color: $color-dark-blue-1;
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title;
+
   @include flex(space-between, center, row, none);
 }
 
 .header {
-  @include flex(flex-start, center, row, none);
   font-size: $font-size-page-title-lg;
   font-weight: $font-weight-regular;
   color: $color-dark-blue-1;
   height: 102px;
+
+  @include flex(flex-start, center, row, none);
 }
 
 .backButton {
@@ -60,14 +62,10 @@
 }
 
 .cardList {
-  display: flex;
-  grid-column-gap: 22px;
+  display: grid;
+  grid-column-gap: 48px;
   grid-row-gap: 48px;
-  width: 1518px;
-
-  &:nth-child(4) {
-    grid-column-gap: 29px;
-  }
+  grid-template-columns: 400px 400px 400px;
 }
 
 .noResultsMessage {

--- a/src/pages/student/categories/CategoryList/index.module.scss
+++ b/src/pages/student/categories/CategoryList/index.module.scss
@@ -8,48 +8,65 @@
   gap: $gap;
 }
 
-.cardList {
-  display: grid;
-  grid-column-gap: 48px;
-  grid-row-gap: 48px;
-  grid-template-columns: 289px 289px 289px 289px;
-}
-
-#cardHeader {
-  background-color: $color-light-blue-1;
-  border-radius: 2px;
-  width: 290px;
-  height: 167px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  position: relative;
-  z-index: 1;
-  padding: 15px;
-}
-
-.card {
-  height: 217px;
-  width: 292px;
-}
-
-.cardContent {
-  background-color: rgba(34, 60, 119, 0.2);
-  border-radius: 10px;
-  padding: 85px;
-  margin-top: 10px;
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
 .headerSection {
   height: 128px;
-  @include flex(center, none, column, 5px);
   margin: 0px;
+
+  @include flex(center, none, column, 5px);
 }
 
 .title {
   font-weight: $font-weight-medium;
   font-size: $font-size-page-title-lg;
   margin: 0px;
+}
+
+.categoryConditionsStyle {
+  margin-bottom: 45px;
+
+  @include flex(flex-start, center, row, 50px);
+}
+
+.cardList {
+  display: grid;
+  grid-column-gap: 48px;
+  grid-row-gap: 48px;
+  grid-template-columns: 400px 400px 400px;
+}
+
+.card {
+  height: 217px;
+  width: 400px;
+}
+
+#cardHeader {
+  background-color: $color-light-blue-1;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 2px;
+  position: relative;
+  height: 167px;
+  padding: 20px;
+  width: auto;
+  z-index: 1;
+}
+
+.cardTitle {
+  font-size: $font-size-lg;
+  color: $color-dark-blue-1;
+  line-height: 21px;
+}
+
+.cardSubtitle {
+  font-size: $font-size-md;
+  font-weight: 300;
+  line-height: 16px;
+}
+
+.cardContent {
+  background-color: rgba(34, 60, 119, 0.2);
+  border-radius: 10px;
+  padding: 85px;
+  margin: 10px;
 }
 
 .loading {
@@ -63,12 +80,6 @@
   margin-left: 10px;
 }
 
-.cardTitle {
-  color: $color-dark-blue-1;
-  font-size: $font-size-sm;
-  font-weight: $font-weight-regular;
-}
-
 .noResultsMessage {
   margin: 220px 0px;
 
@@ -80,55 +91,9 @@
   font-size: $font-size-page-title;
 }
 
-.cardTitle {
-  font-size: $font-size-lg;
-  font-weight: $font-weight-regular;
-  line-height: 21px;
-}
-
-.cardSubtitle {
-  font-size: $font-size-md;
-  font-weight: 300;
-  line-height: 16px;
-}
-
 #subTitle {
   font-size: $font-size-sm;
   font-weight: 500;
   color: $color-dark-blue-3;
   margin-top: 3px;
-}
-
-.categoryConditionsStyle {
-  display: flex;
-  gap: 50px;
-  align-items: center;
-  margin-bottom: 45px;
-}
-
-.dropdownStyle {
-  display: flex;
-  justify-content: space-between;
-  background-color: #ffffff;
-  border: 1px $color-light-blue-2 solid;
-  color: $color-dark-blue-1;
-  text-decoration: none;
-  width: 120px;
-  height: 30px;
-}
-
-.dropdownStyle:hover {
-  color: $color-dark-blue-1;
-}
-
-.dropdownItemStyle {
-  width: 120px;
-}
-
-.dropdownFocus {
-  background-color: rgba(224, 234, 236, 0.6);
-}
-
-.dropdownMenu {
-  width: 120px;
 }

--- a/src/pages/student/categories/CategoryList/index.module.scss
+++ b/src/pages/student/categories/CategoryList/index.module.scss
@@ -58,7 +58,7 @@
 
 .cardSubtitle {
   font-size: $font-size-md;
-  font-weight: 300;
+  font-weight: $font-weight-light;
   line-height: 16px;
 }
 
@@ -93,7 +93,7 @@
 
 #subTitle {
   font-size: $font-size-sm;
-  font-weight: 500;
+  font-weight: $font-weight-medium;
   color: $color-dark-blue-3;
   margin-top: 3px;
 }

--- a/src/pages/student/main/Dashboard/components/Recent/index.module.scss
+++ b/src/pages/student/main/Dashboard/components/Recent/index.module.scss
@@ -2,7 +2,7 @@
 
 .card {
   margin-bottom: 25px;
-  width: 310px;
+  width: 400px;
 }
 
 .cardHeader {

--- a/src/pages/student/main/Dashboard/components/Recent/index.module.scss
+++ b/src/pages/student/main/Dashboard/components/Recent/index.module.scss
@@ -17,6 +17,12 @@
   display: inline-block;
   font-weight: $font-weight-medium;
   font-size: $font-size-lg;
+
+  display: -webkit-box;
+  max-width: 295px;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .quizInfoLabel {

--- a/src/pages/student/main/Dashboard/index.module.scss
+++ b/src/pages/student/main/Dashboard/index.module.scss
@@ -10,7 +10,7 @@
 .recentQuizzesContainer {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 48px;
 }
 
 .pageTitle {
@@ -51,7 +51,7 @@
   border: 1px rgba(0, 0, 0, 0.185) solid;
 }
 
-.listTable{
+.listTable {
   @extend %style-table-head;
   text-align: left;
 


### PR DESCRIPTION
### Issue Link

- E_CLASSROOM-348 [Bugfix] Quiz title in /categories is not truncated

### Definition of Done
* [x] Only 3 cards per row
* [x] Title should be truncated if it is too long
* [x] Categories and quizzes cards are updated
* [x] Also update the student dashboard "Recent" cards

### Related PR

- BE Link: https://github.com/framgia/sph-classroom-els-be/pull/86

### Notes
#### Main note
- Updated the Recent Quizzes section in the Dashboard Page to display only 3 instead of 4.
- To test if the title is being truncated, please create a quiz with a very long title.

#### Pages Affected
- Dashboard: Page http://localhost:3003/
- Categories Page: http://localhost:3003/categories
- Subcategories and Quizzes Page: http://localhost:3003/categories/1/sub

### Scenarios/ Test Cases
* [x] There should only be 3 cards per row
* [x] Title should be truncated if it is too long
* [x] Categories and quizzes cards are updated
* [x] The student dashboard "Recent" section should also only display 3 cards

### Screenshots
DASHBOARD:
> ![image](https://user-images.githubusercontent.com/91049234/159857274-4c748a95-75ab-4041-a8d5-a081bf6162f5.png)

CATEGORIES LIST PAGE:
> ![image](https://user-images.githubusercontent.com/91049234/159857362-29b97c50-dbc2-43b1-bc2f-4b1031229558.png)

SUBCATEGORIES AND QUIZZES LIST PAGE:
> ![image](https://user-images.githubusercontent.com/91049234/159857440-a5dd6ab5-67bd-4564-afd9-51b325aaa48a.png)
