### PR TITLE
E_CLASSROOM-354 [Bugfix][Admin] User name will not update after name update

### DIFF
--- a/src/components/NavigationSideBar/index.js
+++ b/src/components/NavigationSideBar/index.js
@@ -1,27 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useToast } from '../../hooks/useToast';
-import Navbar from 'react-bootstrap/Navbar';
-import { Nav, Container } from 'react-bootstrap';
+import { Nav, Navbar, Container } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { ImUser } from 'react-icons/im';
 import { BiCategory, BiLogOutCircle, BiShieldQuarter } from 'react-icons/bi';
 import { BsCardChecklist } from 'react-icons/bs';
-import Cookies from 'js-cookie';
-import AdminApi from '../../api/Admin';
-
-import style from './index.module.css';
+import { AdminContext } from '../../context/adminContext';
 import AuthApi from '../../api/Auth';
+import Cookies from 'js-cookie';
+import style from './index.module.css';
 
 const NavigationSideBar = () => {
   const toast = useToast();
-  const [profileName, setprofileName] = useState(null);
-  const loggedInUserId = Cookies.get('admin_id');
-
-  useEffect(() => {
-    AdminApi.getAllUsers(loggedInUserId).then(({ data }) => {
-      setprofileName(data[0]);
-    });
-  }, []);
+  const { name } = useContext(AdminContext);
 
   const onLogout = async () => {
     toast('Processing', 'Logging out...');
@@ -42,7 +33,7 @@ const NavigationSideBar = () => {
       </Navbar.Brand>
       <div>
         <div className={`${style.displayFlexColumn} ${style.adminInfo}`}>
-          <p className={style.username}>{profileName?.name}</p>
+          <p className={style.username}>{name}</p>
           <p className={style.userRole}>Admin</p>
         </div>
       </div>

--- a/src/context/adminContext.js
+++ b/src/context/adminContext.js
@@ -1,0 +1,21 @@
+import React, { createContext, useState } from 'react';
+import { PropTypes } from 'prop-types';
+import Cookies from 'js-cookie';
+
+export const AdminContext = createContext();
+
+export function AdminProvider({ children }) {
+  const adminName = Cookies.get('admin_name');
+
+  const [name, setName] = useState(adminName);
+
+  return (
+    <AdminContext.Provider value={{ name, setName }}>
+      {children}
+    </AdminContext.Provider>
+  );
+}
+
+AdminProvider.propTypes = {
+  children: PropTypes.any
+};

--- a/src/pages/admin/main/Login/index.js
+++ b/src/pages/admin/main/Login/index.js
@@ -37,9 +37,12 @@ const AdminLogin = () => {
         password,
         loginType: 'Admin'
       });
+
       Cookies.set('access_token', response.data.token);
       Cookies.set('admin_id', response.data.user.id);
+      Cookies.set('admin_name', response.data.user.name);
       Cookies.set('user_type', 'admin');
+
       window.location = '/admin/categories';
     } catch (error) {
       toast('Error', 'Incorrect Credentials, please try again.');

--- a/src/pages/admin/profile/EditProfile/index.js
+++ b/src/pages/admin/profile/EditProfile/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Link, useHistory } from 'react-router-dom';
 import { useToast } from '../../../../hooks/useToast';
@@ -8,6 +8,7 @@ import Alert from 'react-bootstrap/Alert';
 import Form from 'react-bootstrap/Form';
 import Card from 'react-bootstrap/Card';
 import Spinner from 'react-bootstrap/Spinner';
+import { AdminContext } from '../../../../context/adminContext';
 import Button from '../../../../components/Button';
 import InputField from '../../../../components/InputField';
 import ProfileEditApi from '../../../../api/ProfileEdit';
@@ -19,6 +20,7 @@ const AdminEditProfile = () => {
   const history = useHistory();
   const loggedInUserId = Cookies.get('admin_id');
   const { control, handleSubmit } = useForm();
+  const { setName } = useContext(AdminContext);
 
   const [errors, setErrors] = useState({});
   const [showAlert, setShowAlert] = useState(false);
@@ -49,6 +51,7 @@ const AdminEditProfile = () => {
 
     await ProfileEditApi.profileEdit({ name, email, password })
       .then(() => {
+        setName(name);
         history.push('/admin/profile');
         toast('Success', 'Successfully Changed Your Account Information.');
       })

--- a/src/pages/admin/profile/EditProfile/index.js
+++ b/src/pages/admin/profile/EditProfile/index.js
@@ -51,6 +51,7 @@ const AdminEditProfile = () => {
 
     await ProfileEditApi.profileEdit({ name, email, password })
       .then(() => {
+        Cookies.set('admin_name', name);
         setName(name);
         history.push('/admin/profile');
         toast('Success', 'Successfully Changed Your Account Information.');

--- a/src/routes/middleware/AdminRoute/index.js
+++ b/src/routes/middleware/AdminRoute/index.js
@@ -1,13 +1,14 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 
+import { AdminProvider } from '../../../context/adminContext';
 import AuthService from '../../../services/AuthService';
 import Navbar from '../../../components/NavigationSideBar';
 import { PropTypes } from 'prop-types';
 
 const AdminRoute = ({ sidebar = true, component: Component, ...rest }) => {
   return (
-    <Fragment>
+    <AdminProvider>
       {/* Navigation Side Bar */}
       {sidebar ? <Navbar /> : ''}
 
@@ -31,7 +32,7 @@ const AdminRoute = ({ sidebar = true, component: Component, ...rest }) => {
           );
         }}
       ></Route>
-    </Fragment>
+    </AdminProvider>
   );
 };
 


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-354

### Definition of Done
* [x] User name should reflect after updating the name
* [x] Should not need to refresh the page

### Notes
#### Main note
- To test, try editing your admin name, the newly updated name should be displayed automatically in the sidebar without refreshing the page

#### Pages Affected
- ADMIN SIDEBAR: http://localhost:3003/admin/profile

### Scenarios/ Test Cases
- [x] After editing your admin name, the newly updated name should be displayed automatically in the sidebar without 

### Screenshots
![AUTOMATIC NAME CHANGE](https://user-images.githubusercontent.com/91049234/159871084-458fdf96-7515-4aa0-ada8-427cb8e49e12.gif)
