### PR TITLE
E_CLASSROOM-356 [Bugfix] Sorting/Searching a table should reset to page 1

### DIFF
--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -30,7 +30,7 @@ const SearchBar = ({ placeholder, search, setSearch }) => {
     setSearchValue(e.target.value);
 
     if (e.target.value.length === 0) {
-      setSearch('');
+      setSearch(' ');
     }
   };
 

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -31,14 +31,14 @@ const AdminList = () => {
   const [search, setSearch] = useState(searchVal ? searchVal : '');
   const [sortOptions, setSortOptions] = useState({
     sortBy,
-    sortDirection,
+    sortDirection
   });
 
   const tableHeaderNames = [
     { title: 'ID', canSort: true },
     { title: 'Action', canSort: false },
     { title: 'Name', canSort: true },
-    { title: 'Email', canSort: true },
+    { title: 'Email', canSort: true }
   ];
 
   useEffect(() => {
@@ -48,6 +48,10 @@ const AdminList = () => {
 
     load();
   }, [page, search, sortOptions]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search, sortOptions]);
 
   useEffect(() => {
     if (deleteConfirmed) {
@@ -75,7 +79,7 @@ const AdminList = () => {
       page,
       search,
       sortBy: sortOptions.sortBy,
-      sortDirection: sortOptions.sortDirection,
+      sortDirection: sortOptions.sortDirection
     })
       .then(({ data }) => {
         setAdminAccounts(data.data);

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -29,6 +29,7 @@ const AdminList = () => {
   const [totalItems, setTotalItems] = useState(0);
   const [lastPage, setLastPage] = useState(0);
   const [search, setSearch] = useState(searchVal ? searchVal : '');
+  const [changeList, setChangeList] = useState(false);
   const [sortOptions, setSortOptions] = useState({
     sortBy,
     sortDirection
@@ -47,10 +48,13 @@ const AdminList = () => {
     );
 
     load();
-  }, [page, search, sortOptions]);
+  }, [changeList]);
 
   useEffect(() => {
-    setPage(1);
+    if (search || sortOptions.sortBy) {
+      setPage(1);
+      setChangeList(!changeList);
+    }
   }, [search, sortOptions]);
 
   useEffect(() => {
@@ -94,6 +98,7 @@ const AdminList = () => {
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
+    setChangeList(!changeList);
   };
 
   const renderTableData = () => {

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -33,14 +33,14 @@ const CategoryList = () => {
 
   const [sortOptions, setSortOptions] = useState({
     sortBy,
-    sortDirection,
+    sortDirection
   });
 
   const tableHeaderNames = [
     { title: 'ID', canSort: true },
     { title: 'Action', canSort: false },
     { title: 'Name', canSort: true },
-    { title: 'Description', canSort: false },
+    { title: 'Description', canSort: false }
   ];
 
   useEffect(() => {
@@ -53,13 +53,17 @@ const CategoryList = () => {
     load();
   }, [page, search, sortOptions]);
 
+  useEffect(() => {
+    setPage(1);
+  }, [search, sortOptions]);
+
   const load = () => {
     CategoryApi.listOfCategories({
       page: page,
       search,
       sortBy: sortOptions.sortBy,
       sortDirection: sortOptions.sortDirection,
-      listCondition: 'paginated',
+      listCondition: 'paginated'
     }).then(({ data }) => {
       setCategories(data.data);
       setPerPage(data.per_page);

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -26,6 +26,7 @@ const CategoryList = () => {
   const [deleteConfirmed, setDeleteConfirmed] = useState(false);
   const [itemToDelete, setItemToDelete] = useState({});
   const [categories, setCategories] = useState(null);
+  const [changeList, setChangeList] = useState(false);
   const [canDelete, setCanDelete] = useState(false);
   const [totalItems, setTotalItems] = useState(0);
   const [lastPage, setLastPage] = useState(0);
@@ -51,10 +52,13 @@ const CategoryList = () => {
     );
 
     load();
-  }, [page, search, sortOptions]);
+  }, [changeList]);
 
   useEffect(() => {
-    setPage(1);
+    if (search || sortOptions.sortBy) {
+      setPage(1);
+      setChangeList(!changeList);
+    }
   }, [search, sortOptions]);
 
   const load = () => {
@@ -93,6 +97,7 @@ const CategoryList = () => {
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
+    setChangeList(!changeList);
   };
 
   const onCategoryChecker = (category) => {

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -23,7 +23,7 @@ const QuizList = () => {
   const sortBy = queryParams.get('sortBy') || '';
   const sortDirection = queryParams.get('sortDirection') || '';
 
-  const TYPE = 'withoutPathDisplay'; 
+  const TYPE = 'withoutPathDisplay';
   const history = useHistory();
   const toast = useToast();
 
@@ -118,7 +118,7 @@ const QuizList = () => {
 
   useEffect(() => {
     setPage(1);
-  }, [filter, search]);
+  }, [filter, search, sortOptions]);
 
   useEffect(() => {
     if (deleteConfirmed) {

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -43,6 +43,7 @@ const QuizList = () => {
   const [lastPage, setLastPage] = useState(0);
   const [filter, setFilter] = useState(filterVal ? filterVal : '');
   const [search, setSearch] = useState(searchVal ? searchVal : '');
+  const [changeList, setChangeList] = useState(false);
   const [sortOptions, setSortOptions] = useState({
     sortBy,
     sortDirection
@@ -114,10 +115,13 @@ const QuizList = () => {
     );
 
     load();
-  }, [page, sortOptions, search, filter]);
+  }, [changeList]);
 
   useEffect(() => {
-    setPage(1);
+    if (filter || search || sortOptions.sortBy) {
+      setPage(1);
+      setChangeList(!changeList);
+    }
   }, [filter, search, sortOptions]);
 
   useEffect(() => {
@@ -141,6 +145,7 @@ const QuizList = () => {
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
+    setChangeList(!changeList);
   };
 
   const renderTableData = () => {


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-356

### Definition of Done
- [x] When a user sorts/searches a table, the pagination should go back to page 1 instead of staying on the same page

### Notes
#### Pages Affected
- CATEGORIES LIST PAGE: http://localhost:3003/admin/categories
- QUIZZES LIST PAGE: http://localhost:3003/admin/quizzes
- ADMIN LIST PAGE: http://localhost:3003/admin/users

### Scenarios/ Test Cases
- [x] When a user sorts/searches a table, the pagination should go back to page 1 instead of staying on the same page

### Screenshots
![RESET PAGE NUMBER](https://user-images.githubusercontent.com/91049234/159886402-d8f0b261-e501-4424-815e-83ffc0c0c78d.gif)
