### PR TITLE
E_CLASSROOM-357 [Bugfix] Clicking on the cancel button redirects to blank page

### DIFF
--- a/src/pages/admin/Admin/CreateAdmin/index.js
+++ b/src/pages/admin/Admin/CreateAdmin/index.js
@@ -101,7 +101,7 @@ const CreateAdmin = () => {
           type="submit"
           disabled={submitStatus}
         />
-        <Link to="/admin/admin-accounts" className={style.cancelButton}>
+        <Link to="/admin/users" className={style.cancelButton}>
           Cancel
         </Link>
       </Form>


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-357

### Definition of Done
- [x] It should redirect back to the admin list page when clicking the cancel button in the Create Admin form.

### Notes
#### Pages Affected
- http://localhost:3003/admin/create-admin-account

### Scenarios/ Test Cases
- [x] It should redirect back to the admin list page when clicking the cancel button in the Create Admin form.

### Screenshots
![CANCEL REDIRECT](https://user-images.githubusercontent.com/91049234/159889972-86e06e6d-3b13-4997-bb05-5fdbaa76d873.gif)
