### PR TITLE
E_CLASSROOM-358 [Bugfix] Deleting with only one data will stay in the same page

### DIFF
--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -65,7 +65,13 @@ const AdminList = () => {
         .then(({ data }) => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
-          load();
+
+          if (adminAccounts?.length === 1) {
+            setPage(page === 1 ? page : page - 1);
+            setChangeList(!changeList);
+          } else {
+            load();
+          }
         })
         .catch(() =>
           toast(

--- a/src/pages/admin/Admin/AdminList/index.js
+++ b/src/pages/admin/Admin/AdminList/index.js
@@ -66,8 +66,8 @@ const AdminList = () => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
 
-          if (adminAccounts?.length === 1) {
-            setPage(page === 1 ? page : page - 1);
+          if (adminAccounts?.length === 1 && page != 1) {
+            setPage(page - 1);
             setChangeList(!changeList);
           } else {
             load();

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -84,7 +84,13 @@ const CategoryList = () => {
         .then(({ data }) => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
-          load();
+
+          if (categories?.length === 1) {
+            setPage(page === 1 ? page : page - 1);
+            setChangeList(!changeList);
+          } else {
+            load();
+          }
         })
         .catch(() =>
           toast(

--- a/src/pages/admin/categories/CategoryList/index.js
+++ b/src/pages/admin/categories/CategoryList/index.js
@@ -45,8 +45,6 @@ const CategoryList = () => {
   ];
 
   useEffect(() => {
-    setCategories(null);
-
     history.push(
       `?page=${page}&search=${search}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
     );
@@ -62,6 +60,8 @@ const CategoryList = () => {
   }, [search, sortOptions]);
 
   const load = () => {
+    setCategories(null);
+
     CategoryApi.listOfCategories({
       page: page,
       search,
@@ -85,8 +85,8 @@ const CategoryList = () => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
 
-          if (categories?.length === 1) {
-            setPage(page === 1 ? page : page - 1);
+          if (categories?.length === 1 && page != 1) {
+            setPage(page - 1);
             setChangeList(!changeList);
           } else {
             load();

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -133,8 +133,8 @@ const QuizList = () => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
 
-          if (adminQuiz?.length === 1) {
-            setPage(page === 1 ? page : page - 1);
+          if (adminQuiz?.length === 1 && page != 1) {
+            setPage(page - 1);
             setChangeList(!changeList);
           } else {
             load();

--- a/src/pages/admin/quizzes/QuizList/index.js
+++ b/src/pages/admin/quizzes/QuizList/index.js
@@ -132,7 +132,13 @@ const QuizList = () => {
         .then(({ data }) => {
           toast('Success', data.message);
           setDeleteConfirmed(false);
-          load();
+
+          if (adminQuiz?.length === 1) {
+            setPage(page === 1 ? page : page - 1);
+            setChangeList(!changeList);
+          } else {
+            load();
+          }
         })
         .catch(() =>
           toast(


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-358

### Definition of Done
* [x] Should redirect to previous page (from page 3 to 2) when deleting the only item from that page

### Notes
#### Pages Affected
- CATEGORIES LIST PAGE: http://localhost:3003/admin/categories
- QUIZZES LIST PAGE: http://localhost:3003/admin/quizzes
- ADMIN LIST PAGE: http://localhost:3003/admin/users

### Scenarios/ Test Cases
* [x] Should redirect to previous page (from page 3 to 2) when deleting the only item from that page

### Screenshots
![DELETE ONE ITEM REDIRECT TO ANOTHER PAGE](https://user-images.githubusercontent.com/91049234/159896405-3c3014ae-e282-43e8-a124-474528ffc466.gif)
