### PR TITLE
E_CLASSROOM-359 [Bugfix] Choice text is not truncated if it is too long

### DIFF
--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/components/FillInTheBlankType/index.js
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/components/FillInTheBlankType/index.js
@@ -26,11 +26,11 @@ const FillInTheBlankType = ({ question, getAnswer, answer, getPoint }) => {
     <Fragment>
       <div className={style.question}>
         <p>{question.question}</p>
-        <div className="mt-5">
+        <div className="mt-5" style={{height: '42px'}}>
           <InputField
+            inputStyle={style.answerInput}
             type="text"
             value={answer}
-            fieldSize="lg"
             placeholder="Enter your answer here"
             onChange={getQuestionPoints}
           />

--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
@@ -1,7 +1,7 @@
 @use '../../../../../styles/variables' as *;
 
 .card {
-  width: 500px;
+  width: 800px;
   margin-top: 130px;
 }
 
@@ -31,7 +31,7 @@
 
 .cardBody {
   padding: 30px 50px;
-  width: 500px;
+  width: 800px;
 }
 
 .timer {
@@ -97,9 +97,17 @@
   margin: 70px 0px 20px;
 }
 
+.answerInput {
+  height: 42px;
+}
+
 .choices {
-  color: #48535b;
+  color: $color-dark-blue-1;
   font-size: $font-size-base;
   font-weight: $font-weight-light;
   margin-left: 20px;
+  white-space: nowrap;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+  width: 619px;
 }


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-359
### Definition of Done
- [x] Choice text is not truncated and card width is too small
- [x] Text should be truncated if it will not fit in the card] 
- [x] Adjust the width of the card to 800px

### Commands to Run


### Notes
#### Main note
- http://localhost:3003/categories/1/quizzes/1/questions
#### Pages Affected
- Student Question page

### Scenarios/ Test Cases
- [x] it should truncated if the text is too long
- [x] the width is 800px
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160068474-f12a8308-ec7e-4781-84d3-2bae51a2c3bd.png)
