### PR TITLE
E_CLASSROOM-363 [Bugfix] Activities card layout is broken

### DIFF
--- a/src/components/DataTable/index.module.scss
+++ b/src/components/DataTable/index.module.scss
@@ -54,4 +54,6 @@
   width: 100%;
   margin-top: 21px;
   border-collapse: inherit;
+  border : 0px solid transparent;
+  margin: 0px
 }

--- a/src/pages/student/main/Dashboard/components/FriendsActivities/index.js
+++ b/src/pages/student/main/Dashboard/components/FriendsActivities/index.js
@@ -41,12 +41,12 @@ const FriendsActivities = () => {
   const renderTableData = () => {
     return friendsActivities.map((friendActivity, idx) => {
       return (
-        <tr key={idx} className={style.bodyForTheFriendsAct}>
-          <td className={style.listTable}>
+        <tr key={idx}>
+          <td>
             {iconDisplay(friendActivity.subject_type)}
             {friendActivity.description}
           </td>
-          <td className={style.forSeccolum}>
+          <td>
             <Moment fromNow>{friendActivity.created_at}</Moment>
           </td>
         </tr>

--- a/src/pages/student/main/Dashboard/components/FriendsActivities/index.module.scss
+++ b/src/pages/student/main/Dashboard/components/FriendsActivities/index.module.scss
@@ -6,7 +6,8 @@
 
 .card {
   width: 639px;
-  height: 475px;
+  min-height: 475px;
+  margin-bottom: 40px;
 }
 
 .cardHeader {

--- a/src/pages/student/main/Dashboard/index.module.scss
+++ b/src/pages/student/main/Dashboard/index.module.scss
@@ -24,7 +24,8 @@
 
 .card {
   width: 639px;
-  height: 475px;
+  min-height: 475px;
+  margin-bottom: 40px;
 }
 
 .cardHeader {


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-363

### Definition of Done
- [X] Data will not overflow
- [X] min-height 475px
- [X] Both Categories Learned and Friend's Activities cards have the same behavior

### Commands to Run
N/A

### Notes
#### Main note
1. Go to /dashboard
2. Friend's activities card should have a lot of rows
3. Data overflows outside of the card

#### Pages Affected
- http://localhost:3003/

### Scenarios/ Test Cases
- [ ] Data will not overflow
- [ ] min-height 475px
- [ ] Both Categories Learned and Friend's Activities cards have the same behavior
#### User Interface
N/A
#### User Experience 
N/A
#### Functionality
N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89382909/160070274-0f89133e-6b01-469f-be03-61317b028e6c.png)
