### PR TITLE
E_CLASSROOM-361 [Bugfix] Recent and Friend activities should have the same min-height

### DIFF
--- a/src/pages/student/profile/ProfileDetail/index.module.scss
+++ b/src/pages/student/profile/ProfileDetail/index.module.scss
@@ -59,7 +59,8 @@
 .cardBody {
   background-color: $color-white;
   width: 630px;
-  border-radius: 0px 0px 10px 10px;
+  min-height: 475px;
+  border-radius: 0px 0px 5px 5px;
   margin-bottom: 40px
 }
 


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-361
### Definition of Done
- [x] Same implementation in the dashboard
- [x] Height of the two cards are the same
- [x] Should have the same minimum height

### Commands to Run


### Notes
#### Main note
- http://localhost:3003/profile
#### Pages Affected
- Student Profile Page 

### Scenarios/ Test Cases
- [ ] it should have the same minimum height 
- [ ] Same Implementation in the dashboard
#### User Interface
- N/A 
#### User Experience 
- N/A 
#### Functionality
- N/A 
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160083346-34161947-57e6-4f93-aed2-a965dbc0ceca.png)
![image](https://user-images.githubusercontent.com/89514595/160083414-bf4cf80c-61aa-4409-8942-af0551444a58.png)
