### PR TITLE
E_CLASSROOM-370 [Improvement] Add a section background if there is no related quiz

### DIFF
--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -145,7 +145,7 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
           <footer>
             <h2 className={style.relatedQuizzesText}>Related Quizzes</h2>
             {quizRelated?.length === 0 ? (
-              <div className={style.noRelatedQuizzesMessageContainer}>
+              <div className={style.messageContainer}>
                 <center>
                   <span>No Related Quizzes</span>
                 </center>
@@ -153,12 +153,7 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
             ) : (
               <div className={style.relatedQuizzes}>
                 {quizRelated?.map((relatedQuiz, idx) => {
-                  return (
-                    <Recent
-                      relatedQuiz={relatedQuiz}
-                      key={idx}
-                    />
-                  );
+                  return <Recent relatedQuiz={relatedQuiz} key={idx} />;
                 })}
               </div>
             )}

--- a/src/pages/student/quizzes/QuizResult/index.module.scss
+++ b/src/pages/student/quizzes/QuizResult/index.module.scss
@@ -151,3 +151,11 @@
   column-gap: 50px;
   margin-bottom: 33px;
 }
+
+.messageContainer {
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $color-white;
+}


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-370

### Definition of Done
- [x] There should already be a white background for the `No Related Quiz` message.

### Notes
#### Main note
- Please take a quiz with no related quizzes to see the `No Related Quiz` message

#### Pages Affected
- QUIZ RESULTS PAGE:  http://localhost:3003/categories/5/quizzes/5/questions

### Scenarios/ Test Cases
- [x] it should `have a No Related Quiz message with a white background` when `there are ni list of related quizzes` 

### Screenshots
![image](https://user-images.githubusercontent.com/91049234/160345345-2e19c3a9-0c13-4811-b389-d82a8dfa90e8.png)