### PR TITLE
E_CLASSROOM-369 [Bugfix] Quiz name is not truncated if it is too long

### DIFF
--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -57,7 +57,7 @@
   font-size: $font-size-lg;
 
   display: -webkit-box;
-  max-width: 295px;
+  max-width: 278px;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/index.js
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/index.js
@@ -126,7 +126,7 @@ const QuestionAnswer = () => {
                 <BsFillArrowLeftSquareFill className={style.backButton} />
               </a>
               <div className={style.topic}>
-                <center>{title}</center>
+                <center className={style.toTruncate}>{title}</center>
               </div>
             </Card.Header>
             <Card.Body className={style.cardBody}>

--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
@@ -115,5 +115,5 @@
 .toTruncate {
   @extend %to-truncated-title;
   width: 287px;
-  margin-left: 23px;
+  margin-left: 215px;
 }

--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/indexQuestion.module.scss
@@ -1,5 +1,7 @@
 @use '../../../../../styles/variables' as *;
 
+@use '../../../../../styles/global-styles' as *;
+
 .card {
   width: 800px;
   margin-top: 130px;
@@ -106,8 +108,12 @@
   font-size: $font-size-base;
   font-weight: $font-weight-light;
   margin-left: 20px;
-  white-space: nowrap;
-  text-overflow: ellipsis !important;
-  overflow: hidden !important;
+  @extend %to-truncated-title;
   width: 619px;
+}
+
+.toTruncate {
+  @extend %to-truncated-title;
+  width: 287px;
+  margin-left: 23px;
 }

--- a/src/pages/student/quizzes/QuestionList/index.js
+++ b/src/pages/student/quizzes/QuestionList/index.js
@@ -66,7 +66,7 @@ const QuestionList = () => {
                   <BsFillArrowLeftSquareFill className={style.backButton} />
                 </a>
                 <div className={style.topic}>
-                  <center>{quizInfo?.title}</center>
+                  <center className={style.toTruncate}>{quizInfo?.title}</center>
                 </div>
               </Card.Header>
               <Card.Body className={style.cardBody}>

--- a/src/pages/student/quizzes/QuestionList/index.module.scss
+++ b/src/pages/student/quizzes/QuestionList/index.module.scss
@@ -52,5 +52,5 @@
 .toTruncate {
   @extend %to-truncated-title;
   width: 287px;
-  margin-left: 23px;
+  margin-left: 99px;
 }

--- a/src/pages/student/quizzes/QuestionList/index.module.scss
+++ b/src/pages/student/quizzes/QuestionList/index.module.scss
@@ -1,5 +1,7 @@
 @use '../../../../styles/variables' as *;
 
+@use '../../../../styles/global-styles' as *;
+
 .card {
   width: 548px;
   height: 350px;
@@ -45,4 +47,10 @@
 
 .startButton {
   float: right;
+}
+
+.toTruncate {
+  @extend %to-truncated-title;
+  width: 287px;
+  margin-left: 23px;
 }

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
@@ -73,7 +73,7 @@ const QuestionGrid = ({ quiz }) => {
             <Card>
               <Card.Header className={style.card}>
                 <div className={style.cardTitle}>
-                  <div>
+                  <div className={style.toTruncate}>
                     {quiz?.title}
                   </div>
                   <div className={style.timeStyle}>

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
@@ -1,5 +1,7 @@
 @use '../../../../../../styles/variables' as *;
 
+@use '../../../../../../styles/global-styles' as *;
+
 .card {
   color: $color-dark-blue-1;
   background-color:$color-light-blue-1;
@@ -22,6 +24,11 @@
   justify-content: space-between;
   font-size: $font-size-lg;
   font-weight: $font-weight-regular;
+}
+
+.toTruncate {
+  @extend %to-truncated-title;
+  width: 224px;
 }
 
 .card.fail {

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
@@ -28,7 +28,7 @@
 
 .toTruncate {
   @extend %to-truncated-title;
-  width: 224px;
+  width: 287px;
 }
 
 .card.fail {

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
@@ -28,7 +28,7 @@
 
 .toTruncate {
   @extend %to-truncated-title;
-  width: 287px;
+  width: 214px;
 }
 
 .card.fail {

--- a/src/pages/student/quizzes/QuizList/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/index.module.scss
@@ -1,9 +1,13 @@
 @use '../../../../styles/variables' as *;
 
+@use '../../../../styles/global-styles' as *;
+
 .title {
+  @extend %to-truncated-title;
   font-size: $font-size-page-title-lg;
   font-weight: $font-weight-medium;
   color: $color-dark-blue-1;
+  width: 353px;
   margin: 0px;
 }
 

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/index.js
@@ -48,7 +48,7 @@ const QuizAnswerResult = ({
           className={style.backButton}
         />
         <div className={style.title}>
-          <span>{title}</span>
+          <span className={style.toTruncate}>{title}</span>
         </div>
       </Card.Header>
       <Card.Body className={style.cardBody}>

--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.scss
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.scss
@@ -1,5 +1,7 @@
 @use '../../../../../styles/variables' as *;
 
+@use '../../../../../styles/global-styles' as *;
+
 .card {
   width: 500px;
   margin-top: 130px;
@@ -11,6 +13,12 @@
   align-items: center;
   background-color: $color-light-blue-1;
   box-shadow: $drop-shadow;
+}
+
+.toTruncate {
+  @extend %to-truncated-title;
+  width: 287px;
+  margin-left: 75px;
 }
 
 .backButton {
@@ -26,7 +34,7 @@
   color: #48535b;
   font-size: $font-size-page-title;
   font-weight: $font-weight-semibold;
-  text-align: center;
+  display: inline-flex;
   width: 100%;
 }
 

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -45,7 +45,9 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
         <Container className={style.card}>
           <div className="d-flex justify-content-center align-items-center">
             <Card>
-              <div className={style.resultTopic}>{title}</div>
+              <div className={style.resultTopic}>
+              <center className={style.toTruncate}>{title}</center>
+              </div>
               <Card.Body className={style.resultWholeBodyCard}>
                 <div className={style.resultUpperBodyCard}>
                   <div className={style.resultCardLeft}>

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -46,7 +46,7 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
           <div className="d-flex justify-content-center align-items-center">
             <Card>
               <div className={style.resultTopic}>
-              <center className={style.toTruncate}>{title}</center>
+                <center className={style.toTruncate}>{title}</center>
               </div>
               <Card.Body className={style.resultWholeBodyCard}>
                 <div className={style.resultUpperBodyCard}>

--- a/src/pages/student/quizzes/QuizResult/index.module.scss
+++ b/src/pages/student/quizzes/QuizResult/index.module.scss
@@ -1,10 +1,13 @@
 @use '../../../../styles/variables' as *;
 
+@use '../../../../styles/global-styles' as *;
+
 .card {
   margin: 52px 0px 20px 0px;
 }
 
 .resultTopic {
+  display: flex;
   margin: 0;
   padding: 10px;
   text-align: center;
@@ -158,4 +161,9 @@
   align-items: center;
   justify-content: center;
   background-color: $color-white;
+}
+
+.toTruncate {
+  @extend %to-truncated-title;
+  width: 287px;
 }

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -1,3 +1,9 @@
+
+%to-truncated-title {
+  white-space: nowrap;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+}
 .cardContainer {
   position: absolute;
   height: 100%;


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-369
### Definition of Done
- [x] Quiz name should be truncated if it is too long

### Commands to Run
- N/A

### Notes
#### Main note
- http://localhost:3003/categories/:category_id/quizzes
#### Pages Affected
-Student  Quiz Page

### Scenarios/ Test Cases
- [x] it should be truncated if it is too long
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160347419-1c571564-dbc5-444b-a2b6-c7da9423b861.png)
![image](https://user-images.githubusercontent.com/89514595/160355366-efc923b2-164b-4221-a8d6-bb7f0707e29b.png)
![image](https://user-images.githubusercontent.com/89514595/160365291-2a914f79-3fb5-4a98-824f-bfef62f5c5a9.png)
![image](https://user-images.githubusercontent.com/89514595/160365590-aba5c99b-7dc7-417f-9cc5-b254aac95253.png)
