### PR TITLE
E_CLASSROOM-371 [Bugfix] [Student] [Category list] When user Click all the spinner will spin infinite.

### DIFF
--- a/src/pages/student/categories/CategoryList/index.js
+++ b/src/pages/student/categories/CategoryList/index.js
@@ -121,6 +121,7 @@ function CategoryList() {
         <FilterDropdown
           dropdownItems={dropdownOptions}
           filter={sortByText}
+          onAll={false}
           setFilter={setSortBy}
         />
 


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-371
### Definition of Done
- [X] remove 'all' in the filter for ascending and descending.

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/categories

### Scenarios/ Test Cases
- [x] remove 'all' in the filter for ascending and descending.
#### User Interface
N/A
#### User Experience 
N/A
#### Functionality
N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89382909/160347829-a933ff8e-f12a-41e8-b490-e80bc997f1e8.png)
