### PR TITLE
E_CLASSROOM-372 [Bugfix] Card size in view quiz result is too small

### DIFF
--- a/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.scss
+++ b/src/pages/student/quizzes/QuizResult/QuizAnswerResult/indexAnswer.module.scss
@@ -1,7 +1,7 @@
 @use '../../../../../styles/variables' as *;
 
 .card {
-  width: 500px;
+  width: 800px;
   margin-top: 130px;
 }
 
@@ -32,7 +32,7 @@
 
 .cardBody {
   padding: 30px 50px;
-  width: 500px;
+  width: 800px;
 }
 
 .scoreDisplay {


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-372
### Definition of Done
- [x] Card size is the same with the take quiz
- [x] Please follow implementation of the existing quiz card in the "take a quiz"

### Commands to Run


### Notes
#### Main note
- [x] Title is truncated if it is too long this task is implemented in this task: E_CLASSROOM-369 [Bugfix] Quiz name is not truncated if it is too long 
- http://localhost:3003/categories/9/quizzes/9/questions
#### Pages Affected
- Answer Question Page

### Scenarios/ Test Cases
- [x] it should have the same style with the take quiz
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160384453-c95e3aa5-6569-4bb4-97ba-d69e1bc92b12.png)
