### PR TITLE
E_CLASSROOM-381 [Bugfix] Toaster is not displayed correctly

### DIFF
--- a/src/components/Toaster/index.js
+++ b/src/components/Toaster/index.js
@@ -25,7 +25,7 @@ const Toaster = () => {
   };
 
   return (
-    <ToastContainer position="bottom-end" className="mb-5 me-5">
+    <ToastContainer position="bottom-end" className="mb-5 me-5" style={{zIndex: '2000'}}>
       {toasts &&
         toasts.map((toast, idx) => {
           return (


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-381
### Definition of Done
- [x] Toaster should not be behind the category cards
- [x] Toaster should appear in the foreground together with the add quiz modal

### Commands to Run


### Notes
#### Main note
- http://localhost:3003/admin/login
- http://localhost:3003/login
#### Pages Affected
- All Student and Admin Page that uses toaster

### Scenarios/ Test Cases
- [x] toaster should not be appear behind to all page 
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/160564802-c21e243b-1297-4f39-aefd-5516868dd5f9.png)
![image](https://user-images.githubusercontent.com/89514595/160564867-ca7e10fb-c4ee-45aa-b18b-995920cd82fd.png)
![image](https://user-images.githubusercontent.com/89514595/160565039-2261d7f0-dba7-473e-ab96-08f5c982935c.png)
