### PR TITLE
E_CLASSROOM-386 [Bugfix] Moving a subcategory to root will not reflect

### DIFF
--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -38,9 +38,11 @@ const AddEditCategory = () => {
   const toast = useToast();
 
   useEffect(() => {
-    if (isSaved) {
+    if (isSaved && location) {
       setParentCategoryID(location?.id);
       setLocation(null);
+    } else {
+      setParentCategoryID(null);
     }
   }, [location, isSaved]);
 

--- a/src/pages/admin/categories/AddEditCategory/index.js
+++ b/src/pages/admin/categories/AddEditCategory/index.js
@@ -38,11 +38,13 @@ const AddEditCategory = () => {
   const toast = useToast();
 
   useEffect(() => {
-    if (isSaved && location) {
-      setParentCategoryID(location?.id);
-      setLocation(null);
-    } else {
-      setParentCategoryID(null);
+    if (isSaved) {
+      if (location) {
+        setParentCategoryID(location?.id);
+        setLocation(null);
+      } else {
+        setParentCategoryID(null);
+      }
     }
   }, [location, isSaved]);
 


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-386

### Definition of Done
- [x]  A user should be able to move a subcategory to the root categories in the edit form page.

### Notes
#### Main note
- Try editing a subcategory, and change its current location to the root location.
#### Pages Affected
- Category Hierarchy Page: http://localhost:3003/admin/category-hierarchy

### Scenarios/ Test Cases
- [x] The subcategory should not have a parent category after moving to the root location after saving in the edit form.

### Screenshots
> ![move to root](https://user-images.githubusercontent.com/91049234/160782206-6c7c672a-c6bc-4073-b45e-fed5df49e3f6.gif)
