### PR TITLE
E_CLASSROOM-368 [Bugfix] Dropdown option highlights the previously selected option

### DIFF
--- a/src/components/FilterDropdown/index.js
+++ b/src/components/FilterDropdown/index.js
@@ -61,6 +61,12 @@ const FilterDropdown = ({
     };
   }, [isClicked]);
 
+  useEffect(() => {
+    if(filter){
+      setActiveItem(filter);
+    }
+  }, [filter]);
+
   return (
     <div ref={ref}>
       <Dropdown


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-368
### Definition of Done
- [X] Dropdown option should highlight the default option on newly added questions
- [X] Existing functionalities should not be broken

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/admin/quizzes/2/edit

### Scenarios/ Test Cases
- [x] Dropdown option should highlight the default option on newly added questions
- [x] Existing functionalities should not be broken
#### User Interface
N/A
#### User Experience 
N/A
#### Functionality
N/A
### Screenshots
![success](https://user-images.githubusercontent.com/89382909/160785615-614c602d-f3ae-42c3-aff4-882345ee1b97.gif)

