### PR TITLE
E_CLASSROOM-385 [Bugfix] Blank space is rendered if related quiz has no questions

### DIFF
--- a/src/pages/student/quizzes/QuizResult/Recent/index.module.scss
+++ b/src/pages/student/quizzes/QuizResult/Recent/index.module.scss
@@ -55,6 +55,10 @@
   font-weight: $font-weight-medium;
   font-size: 18px;
   color: $color-dark-blue-1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 180px;
 }
 
 .quizInfo {

--- a/src/pages/student/quizzes/QuizResult/Recent/index.module.scss
+++ b/src/pages/student/quizzes/QuizResult/Recent/index.module.scss
@@ -58,7 +58,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 180px;
+  width: 161px;
 }
 
 .quizInfo {

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -4,6 +4,7 @@
   text-overflow: ellipsis !important;
   overflow: hidden !important;
 }
+
 .cardContainer {
   position: absolute;
   height: 100%;


### PR DESCRIPTION
### Issue Link
- https://framgiaph.backlog.com/view/E_CLASSROOM-385
### Definition of Done
- [x] No blank space should be rendered
- [x] Please follow fix in from the quiz list page
- [x] Existing functionalities are not broken
- [x] Truncate the title too long

### Commands to Run

## Related PR:
- https://github.com/framgia/sph-classroom-els-be/pull/91
### Notes
#### Main note
- http://localhost:3003/categories/1/quizzes/1/questions
#### Pages Affected
- Student Result Page

### Scenarios/ Test Cases
- [x] Existing functionalities are not broken
- [x] it should get data that have questions
#### User Interface
- N/A
#### User Experience 
- N/A
#### Functionality
- N/A
### Screenshots
![image](https://user-images.githubusercontent.com/89514595/161185421-1ca3cf64-08c3-4642-9aa9-a3bff4aea972.png)
