### PR TITLE
E_CLASSROOM-378 [Improvement] [Student] Removing Retake quiz button

### DIFF
--- a/src/pages/student/main/Dashboard/components/Recent/index.js
+++ b/src/pages/student/main/Dashboard/components/Recent/index.js
@@ -42,6 +42,18 @@ const Recent = ({ recentQuizzes, quizzes }) => {
     return 0;
   };
 
+  const retakeButton = () => {
+    if (recentQuizzes.score < passing) {
+      return (
+        <Link
+          to={`/categories/${recentQuizzes.category_id}/quizzes/${recentQuizzes.quiz_id}/questions`}
+        >
+          <p className={style.retake}>Retake Quiz</p>
+        </Link>
+      );
+    }
+  };
+
   return (
     <Card className={style.card}>
       <Card.Header className={style.cardHeader}>
@@ -73,17 +85,7 @@ const Recent = ({ recentQuizzes, quizzes }) => {
               </tr>
               <tr>
                 <td id={style.listTable}></td>
-                <td>
-                  {recentQuizzes.score < passing ? (
-                    <Link
-                      to={`/categories/${recentQuizzes.category_id}/quizzes/${recentQuizzes.quiz_id}/questions`}
-                    >
-                      <p className={style.retake}>Retake Quiz</p>
-                    </Link>
-                  ) : (
-                    ''
-                  )}
-                </td>
+                <td>{retakeButton()}</td>
               </tr>
             </tbody>
           </table>

--- a/src/pages/student/main/Dashboard/components/Recent/index.js
+++ b/src/pages/student/main/Dashboard/components/Recent/index.js
@@ -10,6 +10,7 @@ import style from './index.module.scss';
 
 const Recent = ({ recentQuizzes, quizzes }) => {
   const [questions, setQuestions] = useState(null);
+  const passing = questions?.length / 2;
 
   useEffect(() => {
     QuestionApi.getAll(recentQuizzes.quiz_id).then(({ data }) => {
@@ -73,11 +74,15 @@ const Recent = ({ recentQuizzes, quizzes }) => {
               <tr>
                 <td id={style.listTable}></td>
                 <td>
-                  <Link
-                    to={`/categories/${recentQuizzes.category_id}/quizzes/${recentQuizzes.quiz_id}/questions`}
-                  >
-                    <p className={style.retake}>Retake Quiz</p>
-                  </Link>
+                  {recentQuizzes.score < passing ? (
+                    <Link
+                      to={`/categories/${recentQuizzes.category_id}/quizzes/${recentQuizzes.quiz_id}/questions`}
+                    >
+                      <p className={style.retake}>Retake Quiz</p>
+                    </Link>
+                  ) : (
+                    ''
+                  )}
                 </td>
               </tr>
             </tbody>
@@ -90,7 +95,7 @@ const Recent = ({ recentQuizzes, quizzes }) => {
 
 Recent.propTypes = {
   recentQuizzes: PropTypes.object,
-  quizzes: PropTypes.array
+  quizzes: PropTypes.array,
 };
 
 export default Recent;

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -136,11 +136,15 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                     buttonSize="def"
                     onClick={() => viewResultsPage()}
                   />
-                  <a
-                    href={`/categories/${categoryId}/quizzes/${quizId}/questions`}
-                  >
-                    <Button buttonLabel="Retake Quiz" buttonSize="def" />
-                  </a>
+                  {score < passing ? (
+                    <a
+                      href={`/categories/${categoryId}/quizzes/${quizId}/questions`}
+                    >
+                      <Button buttonLabel="Retake Quiz" buttonSize="def" />
+                    </a>
+                  ) : (
+                    ''
+                  )}
                 </div>
               </Card.Body>
             </Card>
@@ -153,19 +157,18 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                   <span>No Related Quizzes</span>
                 </center>
               </div>
+            ) : !quizRelated ? (
+              <div className={style.spinner}>
+                <Spinner animation="border" role="status"></Spinner>
+                <span>Loading</span>
+              </div>
             ) : (
-              !quizRelated ? (
-                <div className={style.spinner}>
-                  <Spinner animation="border" role="status"></Spinner>
-                  <span>Loading</span>
-                </div>
-              ) : (
-                <div className={style.relatedQuizzes}>
-                  {quizRelated?.map((relatedQuiz, idx) => {
-                    return <Recent relatedQuiz={relatedQuiz} key={idx} />;
-                  })}
-                </div>
-              ))}
+              <div className={style.relatedQuizzes}>
+                {quizRelated?.map((relatedQuiz, idx) => {
+                  return <Recent relatedQuiz={relatedQuiz} key={idx} />;
+                })}
+              </div>
+            )}
           </footer>
         </Container>
       ) : answers ? (
@@ -188,7 +191,7 @@ QuizResult.propTypes = {
   score: PropTypes.number,
   total: PropTypes.number,
   quizId: PropTypes.number,
-  categoryId: PropTypes.number
+  categoryId: PropTypes.number,
 };
 
 export default QuizResult;

--- a/src/pages/student/quizzes/QuizResult/index.js
+++ b/src/pages/student/quizzes/QuizResult/index.js
@@ -40,6 +40,16 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
     setViewResults(!viewResults);
   };
 
+  const retakeButton = () => {
+    if (score < passing) {
+      return (
+        <a href={`/categories/${categoryId}/quizzes/${quizId}/questions`}>
+          <Button buttonLabel="Retake Quiz" buttonSize="def" />
+        </a>
+      );
+    }
+  };
+
   return (
     <div className="d-flex justify-content-center align-items-center">
       {viewResults == false ? (
@@ -136,15 +146,7 @@ const QuizResult = ({ score, total, quizId, categoryId }) => {
                     buttonSize="def"
                     onClick={() => viewResultsPage()}
                   />
-                  {score < passing ? (
-                    <a
-                      href={`/categories/${categoryId}/quizzes/${quizId}/questions`}
-                    >
-                      <Button buttonLabel="Retake Quiz" buttonSize="def" />
-                    </a>
-                  ) : (
-                    ''
-                  )}
+                  {retakeButton()}
                 </div>
               </Card.Body>
             </Card>


### PR DESCRIPTION
### Issue Link
https://framgiaph.backlog.com/view/E_CLASSROOM-378

### Definition of Done
- [x] If the user passed the quiz, the "Retake quiz" button should not be displayed

### Commands to Run
N/A

### Notes
#### Main note
- N/A
#### Pages Affected
- http://localhost:3003/
- http://localhost:3003/categories/7/quizzes/7/questions

### Scenarios/ Test Cases
- [x] If the user passed the quiz, the "Retake quiz" button should not be displayed

### Screenshots
![image](https://user-images.githubusercontent.com/89382692/160812039-ee35d537-becf-4ba7-bfd4-e6cc132ccb9a.png)
![image](https://user-images.githubusercontent.com/89382692/160812081-6e247d16-1dbf-4ec9-b2ca-f11f63d2ce41.png)
