### PR TITLE
E_CLASSROOM-379 [Improvement] [Student] Update quizzes header on categories

### DIFF
--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.js
@@ -53,7 +53,17 @@ const QuizzesCard = ({ category_id, quiz }) => {
       const totalTimeLimit = questions.reduce((total, questions) => {
         return (total += questions.time_limit);
       }, 0);
-      return totalTimeLimit;
+
+      if (totalTimeLimit >= 60) {
+        const mins = totalTimeLimit / 60;
+        const secs = totalTimeLimit % 60;
+
+        return secs > 0
+          ? `${parseInt(mins)} min/s and ${secs} secs`
+          : `${parseInt(mins)} min/s`;
+      } else {
+        return `${totalTimeLimit} secs`;
+      }
     }
   };
 
@@ -65,7 +75,7 @@ const QuizzesCard = ({ category_id, quiz }) => {
             <span className={style.titleHeader}>{quiz?.title}</span>
             <span className={style.clockHeader}>
               <BsClockHistory size="15px" className={style.clockIcon} />
-              {getTotalTimeLimit()} secs
+              {getTotalTimeLimit()}
             </span>
           </div>
         </Card.Header>

--- a/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
+++ b/src/pages/student/categories/CategoryDetail/components/QuizzesCard/index.module.scss
@@ -57,7 +57,7 @@
   font-size: $font-size-lg;
 
   display: -webkit-box;
-  max-width: 278px;
+  max-width: 220px;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
@@ -99,7 +99,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color : $color-black;
+  color: $color-black;
   gap: 10px;
   width: 295px;
 }

--- a/src/pages/student/main/Dashboard/components/Recent/index.js
+++ b/src/pages/student/main/Dashboard/components/Recent/index.js
@@ -19,13 +19,20 @@ const Recent = ({ recentQuizzes, quizzes }) => {
 
   const getTotalTimeLimit = () => {
     if (questions != null) {
-      let total = 0;
+      const totalTimeLimit = questions.reduce((total, questions) => {
+        return (total += questions.time_limit);
+      }, 0);
 
-      for (let x = 0; x < questions.length; x++) {
-        total += questions[x].time_limit;
+      if (totalTimeLimit >= 60) {
+        const mins = totalTimeLimit / 60;
+        const secs = totalTimeLimit % 60;
+
+        return secs > 0
+          ? `${parseInt(mins)} min/s and ${secs} secs`
+          : `${parseInt(mins)} min/s`;
+      } else {
+        return `${totalTimeLimit} secs`;
       }
-
-      return total;
     }
   };
 
@@ -47,7 +54,7 @@ const Recent = ({ recentQuizzes, quizzes }) => {
         <div className={style.titleText}>{recentQuizzes.title}</div>
         <div className={style.timerIcon}>
           <CgTimer size="15px" />
-          {getTotalTimeLimit()} secs
+          {getTotalTimeLimit()}
         </div>
       </Card.Header>
       <Card.Body>

--- a/src/pages/student/main/Dashboard/components/Recent/index.module.scss
+++ b/src/pages/student/main/Dashboard/components/Recent/index.module.scss
@@ -19,7 +19,7 @@
   font-size: $font-size-lg;
 
   display: -webkit-box;
-  max-width: 295px;
+  max-width: 220px;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.js
@@ -48,12 +48,20 @@ const QuestionGrid = ({ quiz }) => {
 
   const getTotalTimeLimit = () => {
     if (questions != null) {
-
       const totalTimeLimit = questions.reduce((total, questions) => {
         return (total += questions.time_limit);
       }, 0);
-      return totalTimeLimit;
-      
+
+      if (totalTimeLimit >= 60) {
+        const mins = totalTimeLimit / 60;
+        const secs = totalTimeLimit % 60;
+
+        return secs > 0
+          ? `${parseInt(mins)} min/s and ${secs} secs`
+          : `${parseInt(mins)} min/s`;
+      } else {
+        return `${totalTimeLimit} secs`;
+      }
     }
   };
 
@@ -61,14 +69,10 @@ const QuestionGrid = ({ quiz }) => {
     <Card>
       <Card.Header className={style.card}>
         <div className={style.cardTitle}>
-          <div className={style.toTruncate}>
-            {quiz?.title}
-          </div>
+          <div className={style.toTruncate}>{quiz?.title}</div>
           <div className={style.timeStyle}>
-            <BsClockHistory
-              size="15px"
-            />
-            {getTotalTimeLimit()} secs
+            <BsClockHistory size="15px" />
+            {getTotalTimeLimit()}
           </div>
         </div>
       </Card.Header>
@@ -100,7 +104,7 @@ const QuestionGrid = ({ quiz }) => {
 };
 
 QuestionGrid.propTypes = {
-  quiz: PropTypes.object,
+  quiz: PropTypes.object
 };
 
 export default QuestionGrid;

--- a/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/components/QuestionGrid/index.module.scss
@@ -4,19 +4,20 @@
 
 .card {
   color: $color-dark-blue-1;
-  background-color:$color-light-blue-1;
+  background-color: $color-light-blue-1;
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
   filter: drop-shadow($drop-shadow);
   margin-bottom: 4px;
 }
+
 .card02 {
   color: $color-dark-blue-1;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
   height: 140px;
+  width: 100%;
   padding-bottom: 14px 0px 14px 0px;
-
 }
 
 .cardTitle {
@@ -55,7 +56,7 @@
   margin-bottom: 0px;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
-  width: 308px;
+  width: 100%;
 }
 
 .ResultScore {
@@ -66,19 +67,19 @@
   font-weight: $font-weight-light;
 }
 
-.timeStyle{
+.timeStyle {
   display: flex;
   align-items: center;
   font-size: $font-size-sm;
-  gap: 5px
+  gap: 5px;
 }
 
 .loading {
   display: flex;
   justify-content: center;
   align-items: center;
-  color : $color-black;
-  gap: 10px
+  color: $color-black;
+  gap: 10px;
 }
 
 .loadingWord {

--- a/src/pages/student/quizzes/QuizList/index.module.scss
+++ b/src/pages/student/quizzes/QuizList/index.module.scss
@@ -27,12 +27,9 @@
 
 #GridCard {
   display: grid;
-  grid-column-gap: 46px;
+  grid-column-gap: 48px;
   grid-row-gap: 48px;
-  grid-template-columns: 339px 339px 339px 339px;
-  grid-template-rows: 216px 216px 216px;
-  height: 747px;
-  width: 1518px;
+  grid-template-columns: 400px 400px 400px;
 }
 
 .loading {
@@ -66,9 +63,9 @@
   height: 50px;
 }
 
-.headerStyle{
+.headerStyle {
   display: flex;
   align-items: center;
   height: 102px;
-  gap: 10px
+  gap: 10px;
 }

--- a/src/pages/student/quizzes/QuizResult/Recent/index.js
+++ b/src/pages/student/quizzes/QuizResult/Recent/index.js
@@ -50,12 +50,20 @@ const Recent = ({ relatedQuiz }) => {
 
   const getTotalTimeLimit = () => {
     if (questions != null) {
-
       const totalTimeLimit = questions.reduce((total, questions) => {
         return (total += questions.time_limit);
       }, 0);
-      return totalTimeLimit;
-      
+
+      if (totalTimeLimit >= 60) {
+        const mins = totalTimeLimit / 60;
+        const secs = totalTimeLimit % 60;
+
+        return secs > 0
+          ? `${parseInt(mins)} min/s and ${secs} secs`
+          : `${parseInt(mins)} min/s`;
+      } else {
+        return `${totalTimeLimit} secs`;
+      }
     }
   };
 
@@ -70,7 +78,7 @@ const Recent = ({ relatedQuiz }) => {
               <span className={style.titleHeader}>{relatedQuiz.title}</span>
               <span className={style.clockHeader}>
                 <BsClockHistory size="15px" className={style.clockIcon} />
-                {getTotalTimeLimit()} secs
+                {getTotalTimeLimit()}
               </span>
             </div>
           </Card.Header>
@@ -96,7 +104,7 @@ const Recent = ({ relatedQuiz }) => {
             </div>
           </Card.Body>
 
-          <a 
+          <a
             href={`/categories/${relatedQuiz.category_id}/quizzes/${relatedQuiz.id}/questions`}
             className={style.quizLink}
           >
@@ -109,8 +117,7 @@ const Recent = ({ relatedQuiz }) => {
 };
 
 Recent.propTypes = {
-  relatedQuiz: PropTypes.object,
+  relatedQuiz: PropTypes.object
 };
-
 
 export default Recent;

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -1,9 +1,9 @@
-
 %to-truncated-title {
   white-space: nowrap;
   text-overflow: ellipsis !important;
   overflow: hidden !important;
 }
+
 .cardContainer {
   position: absolute;
   height: 100%;


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-379

### Definition of Done
- [x] Quiz title should be truncated when the text is too long (It should only be one line)
- [x] seconds should be changed to minutes if more than 60 seconds
- [x] Total time should be one line

### Notes
#### Main note
- Change the time limit to have more than 60 seconds to test

#### Pages Affected
- Dashboard: http://localhost:3003/
- Subcategories with Quizzes Page:  http://localhost:3003/categories/1/sub?page=1&page=1
- Recent Quizzes in the Quiz Result Page: http://localhost:3003/categories/1/quizzes/1/questions

### Scenarios/ Test Cases
- [x] Quiz title should be truncated when the text is too long (It should only be one line)
- [x] seconds should be changed to minutes if more than 60 seconds
- [x] Total time should be one line

### Screenshots
- Recent Quizzes in the Quiz Result Page: 
> ![image](https://user-images.githubusercontent.com/91049234/160821518-3d90cfbd-4cb0-4aba-9c50-1435773ec05c.png)

- Dashboard
> ![image](https://user-images.githubusercontent.com/91049234/160821572-2fcbd9fb-637a-4694-a49b-b658fe4ba4c9.png)

- Subcat with Quizzes
> ![image](https://user-images.githubusercontent.com/91049234/160821646-9fe99339-b6cb-4db7-86b6-6897f95e9214.png)
