### PR TITLE
E_CLASSROOM-388 [Bugfix] When student name is too long the button is misplaced

### DIFF
--- a/src/pages/student/students/StudentList/index.js
+++ b/src/pages/student/students/StudentList/index.js
@@ -73,7 +73,6 @@ const StudentList = () => {
       return (
         <Button
           buttonLabel="Unfollow"
-          buttonStyle={style.button}
           buttonSize="sm"
           onClick={() => {
             onUnfollowClick(userid, name);
@@ -84,7 +83,6 @@ const StudentList = () => {
       return (
         <Button
           buttonLabel="Follow"
-          buttonStyle={style.button}
           buttonSize="sm"
           onClick={() => {
             onFollowClick(userid, name);

--- a/src/pages/student/students/StudentList/index.module.scss
+++ b/src/pages/student/students/StudentList/index.module.scss
@@ -98,6 +98,7 @@
 .studentInfo {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   margin-top: 13px;
   margin-bottom: 55px;
   margin-left: 5px;
@@ -127,17 +128,6 @@
   display: flex;
   font-size: $font-size-md;
   gap: 20px;
-}
-
-.button {
-  margin-right: 5px;
-  margin-left: 267px;
-  margin-top: 13px;
-}
-
-.button:hover {
-  background-color: $color-light-blue-3;
-  color: $color-white;
 }
 
 .noResults,


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-388

### Definition of Done
- [x] The placement of the button should not be changed when the user's name is too long.

### Notes
#### Pages Affected
- Student List Page: http://localhost:3003/students

### Scenarios/ Test Cases
- [x] The placement of the button should not be changed when the user's name is too long.

### Screenshots
![image](https://user-images.githubusercontent.com/91049234/160963323-c3b71437-607b-43fa-b49a-43bffd11db9f.png)
