### PR TITLE
E_CLASSROOM-384 [Improvement][Student] Implement sort in /learnings table

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -63,8 +63,8 @@ const DataTable = ({
     } else if (sortDirection === 'asc') {
       setSortDirection('desc');
     } else {
-      setSortBy('');
-      setSortDirection('');
+      setSortBy(' ');
+      setSortDirection(' ');
     }
   };
 
@@ -97,11 +97,18 @@ const DataTable = ({
           {data.length > 0 ? (
             renderTableData()
           ) : (
-            <span className={onSpinner ? style.noResultsFound : style.noAspects}>No Results Found</span>
+            <span
+              className={onSpinner ? style.noResultsFound : style.noAspects}
+            >
+              No Results Found
+            </span>
           )}
         </tbody>
       ) : (
-        <Button className={onSpinner ? style.spinner : style.noAspects} disabled>
+        <Button
+          className={onSpinner ? style.spinner : style.noAspects}
+          disabled
+        >
           <Spinner animation="border" />
           <span>Loading</span>
         </Button>

--- a/src/pages/student/learnings/LearningList/index.js
+++ b/src/pages/student/learnings/LearningList/index.js
@@ -16,6 +16,7 @@ const LearningList = () => {
   const toast = useToast();
 
   const [learnings, setLearnings] = useState(null);
+  const [changeList, setChangeList] = useState(false);
   const [page, setPage] = useState(pageNum ? parseInt(pageNum) : 1);
   const [perPage, setPerPage] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
@@ -26,16 +27,24 @@ const LearningList = () => {
   });
 
   const tableHeaderNames = [
-    { title: 'Quizzes Learned', canSort: false },
+    { title: 'Quizzes Learned', canSort: true },
     { title: 'Current Score', canSort: false },
-    { title: 'Categories', canSort: false },
+    { title: 'Categories', canSort: true },
     { title: 'Description', canSort: false }
   ];
 
   useEffect(() => {
-    history.push(`?page=${page}`);
+    history.push(
+      `?page=${page}&sortBy=${sortOptions.sortBy}&sortDirection=${sortOptions.sortDirection}`
+    );
 
-    LearningApi.getAll({ page })
+    setLearnings(null);
+
+    LearningApi.getAll({
+      page,
+      sortBy: sortOptions.sortBy,
+      sortDirection: sortOptions.sortDirection
+    })
       .then(({ data }) => {
         setLearnings(data.data);
         setPerPage(data.per_page);
@@ -45,10 +54,18 @@ const LearningList = () => {
       .catch(() =>
         toast('Error', 'There was an error getting the list of learnings.')
       );
-  }, [page]);
+  }, [changeList]);
+
+  useEffect(() => {
+    if (sortOptions.sortBy) {
+      setPage(1);
+      setChangeList(!changeList);
+    }
+  }, [sortOptions]);
 
   const onPageChange = (selected) => {
     setPage(selected + 1);
+    setChangeList(!changeList);
   };
 
   const renderTableData = () => {

--- a/src/pages/student/learnings/LearningList/index.module.scss
+++ b/src/pages/student/learnings/LearningList/index.module.scss
@@ -84,5 +84,6 @@
 
 .pagination {
   float: right;
-  margin-bottom: 30px;
+  margin-top: 33px;
+  padding-bottom: 20px;
 }


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-384

### Definition of Done
- [x] User should be able to sort by quiz name
- [x] User should be able to sort by category
- [x] The sort functionality of this page should have the same behavior as the one on the admin side.

### Related PR

BE Link: https://github.com/framgia/sph-classroom-els-be/pull/92

### Notes
#### Pages Affected
- Learnings Page: http://localhost:3003/learnings

### Scenarios/ Test Cases
- [x] User should be able to sort by quiz name
- [x] User should be able to sort by category
- [x] The sort functionality of this page should have the same behavior as the one on the admin side.

### Screenshots
![SORT LEARNINGS](https://user-images.githubusercontent.com/91049234/160972682-8f0d8080-ed71-4185-bf7b-cb2ce1c49026.gif)
