### PR TITLE
E_CLASSROOM-390 [Bugfix] Choice is highlighted when clicking next question

### DIFF
--- a/src/pages/student/quizzes/QuestionList/QuestionAnswer/components/MultipleChoiceType/index.js
+++ b/src/pages/student/quizzes/QuestionList/QuestionAnswer/components/MultipleChoiceType/index.js
@@ -5,6 +5,11 @@ import style from '../../indexQuestion.module.scss';
 
 const MultipleChoiceType = ({ question, getAnswer, getPoint }) => {
   const [point, setPoint] = useState(0);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    setSelected(null);
+  }, [question]);
 
   useEffect(() => {
     getPoint(point);
@@ -22,6 +27,8 @@ const MultipleChoiceType = ({ question, getAnswer, getPoint }) => {
                 value={choice.id}
                 name="choice"
                 onClick={(e) => {
+                  setSelected(choice.id);
+
                   if (choice.is_correct) {
                     setPoint(1);
                   } else {
@@ -30,7 +37,9 @@ const MultipleChoiceType = ({ question, getAnswer, getPoint }) => {
 
                   getAnswer(e.target.value);
                 }}
+                checked={selected === choice.id}
               />
+
               <span className={style.choices}>{choice.choice}</span>
             </div>
           </Card>


### PR DESCRIPTION
### Issue Link

- https://framgiaph.backlog.com/view/E_CLASSROOM-390

### Definition of Done
- [x] Choice should be blank
- [x] Choice should not be automatically selected when clicking on the next question

### Notes
#### Main note
- To test, create a quiz and all questions should be of type multiple choice.

#### Pages Affected
- Choose the quiz you created in this page: http://localhost:3003/categories?page=1&sortBy=asc&filter=&search=

### Scenarios/ Test Cases
- [x] Choice should not be automatically selected when clicking on the next question
- [x] Choice should be blank

### Screenshots
![QUIZ](https://user-images.githubusercontent.com/91049234/161025912-04172a05-4a46-487a-b1b0-b76191761306.gif)
